### PR TITLE
Fix colors on windows

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -152,12 +152,12 @@ command, for Go.
 	if len(*filesArgs) == 0 {
 		contents, err := ioutil.ReadAll(os.Stdin)
 		kingpin.FatalIfError(err, "")
-		format(os.Stdout, style, lex("", string(contents)))
+		format(w, style, lex("", string(contents)))
 	} else {
 		for _, filename := range *filesArgs {
 			contents, err := ioutil.ReadFile(filename)
 			kingpin.FatalIfError(err, "")
-			format(os.Stdout, style, lex(filename, string(contents)))
+			format(w, style, lex(filename, string(contents)))
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a problem that go-colorble does not work after cc0e4a59ab3a20edf6efea25b49952f8555cae52.

![chroma](https://user-images.githubusercontent.com/9251039/30740757-42819c76-9fcd-11e7-9b89-9dd4c28d9b04.png)
