### PR TITLE
fix HTML entity reference

### DIFF
--- a/lexers/capnproto.go
+++ b/lexers/capnproto.go
@@ -7,7 +7,7 @@ import (
 // Cap'N'Proto Proto lexer.
 var CapNProto = Register(MustNewLexer(
 	&Config{
-		Name:      "Cap&#x27;n Proto",
+		Name:      "Cap'n Proto",
 		Aliases:   []string{"capnp"},
 		Filenames: []string{"*.capnp"},
 		MimeTypes: []string{},


### PR DESCRIPTION
I found a HTML entity reference in lexer name. I fixed `&#x27;` to `'`.