### PR TITLE
Fix order output of chroma cli tool

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -198,12 +198,12 @@ func listAll() {
 	}
 	fmt.Println()
 	fmt.Printf("styles:")
-	for name := range styles.Registry {
+	for _, name := range styles.Names() {
 		fmt.Printf(" %s", name)
 	}
 	fmt.Println()
 	fmt.Printf("formatters:")
-	for name := range formatters.Registry {
+	for _, name := range formatters.Names() {
 		fmt.Printf(" %s", name)
 	}
 	fmt.Println()


### PR DESCRIPTION
Changes output for the chroma cli tool for styles and formatters so that
the output on --list is always in the same order.