### PR TITLE
Adding HasClasses method for HTML formatter

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -20,7 +20,7 @@ func Standalone() Option { return func(f *Formatter) { f.standalone = true } }
 func ClassPrefix(prefix string) Option { return func(f *Formatter) { f.prefix = prefix } }
 
 // WithClasses emits HTML using CSS classes, rather than inline styles.
-func WithClasses() Option { return func(f *Formatter) { f.classes = true } }
+func WithClasses() Option { return func(f *Formatter) { f.Classes = true } }
 
 // TabWidth sets the number of characters for a tab. Defaults to 8.
 func TabWidth(width int) Option { return func(f *Formatter) { f.tabWidth = width } }
@@ -72,7 +72,7 @@ func New(options ...Option) *Formatter {
 type Formatter struct {
 	standalone         bool
 	prefix             string
-	classes            bool
+	Classes            bool // Exported field to detect when classes are being used
 	tabWidth           int
 	lineNumbers        bool
 	lineNumbersInTable bool
@@ -93,12 +93,6 @@ func (f *Formatter) Format(w io.Writer, style *chroma.Style, iterator chroma.Ite
 		}
 	}()
 	return f.writeHTML(w, style, iterator.Tokens())
-}
-
-// HasClasses is a helper function to know if the formatter was initialized
-// with or without the use of CSS classes
-func (f *Formatter) HasClasses() bool {
-	return f.classes
 }
 
 func brightenOrDarken(colour chroma.Colour, factor float64) chroma.Colour {
@@ -137,14 +131,14 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []*chroma
 		return err
 	}
 	css := f.styleToCSS(style)
-	if !f.classes {
+	if !f.Classes {
 		for t, style := range css {
 			css[t] = compressStyle(style)
 		}
 	}
 	if f.standalone {
 		fmt.Fprint(w, "<html>\n")
-		if f.classes {
+		if f.Classes {
 			fmt.Fprint(w, "<style type=\"text/css\">\n")
 			f.WriteCSS(w, style)
 			fmt.Fprintf(w, "body { %s; }\n", css[chroma.Background])
@@ -255,7 +249,7 @@ func (f *Formatter) class(t chroma.TokenType) string {
 }
 
 func (f *Formatter) styleAttr(styles map[chroma.TokenType]string, tt chroma.TokenType) string {
-	if f.classes {
+	if f.Classes {
 		cls := f.class(tt)
 		if cls == "" {
 			return ""

--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -95,6 +95,12 @@ func (f *Formatter) Format(w io.Writer, style *chroma.Style, iterator chroma.Ite
 	return f.writeHTML(w, style, iterator.Tokens())
 }
 
+// HasClasses is a helper function to know if the formatter was initialized
+// with or without the use of CSS classes
+func (f *Formatter) HasClasses() bool {
+	return f.classes
+}
+
 func brightenOrDarken(colour chroma.Colour, factor float64) chroma.Colour {
 	if colour.Brightness() < 0.5 {
 		return colour.Brighten(factor)

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -58,10 +58,3 @@ func TestIteratorPanicRecovery(t *testing.T) {
 	err := New().Format(ioutil.Discard, styles.Fallback, it)
 	assert.Error(t, err)
 }
-
-func TestHasClasses(t *testing.T) {
-	f := New(WithClasses())
-	assert.True(t, f.HasClasses())
-	f = New()
-	assert.False(t, f.HasClasses())
-}

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -58,3 +58,10 @@ func TestIteratorPanicRecovery(t *testing.T) {
 	err := New().Format(ioutil.Discard, styles.Fallback, it)
 	assert.Error(t, err)
 }
+
+func TestHasClasses(t *testing.T) {
+	f := New(WithClasses())
+	assert.True(t, f.HasClasses())
+	f = New()
+	assert.False(t, f.HasClasses())
+}


### PR DESCRIPTION
This PR adds a single method `HasClasses` that returns `true` if the `WithClasses()` functional option was used. Also adds a small test to validate the usage.