### PR TITLE
Select lexer with --filename argument

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -35,6 +35,7 @@ var (
 	unbufferedFlag = kingpin.Flag("unbuffered", "Do not buffer output.").Bool()
 	traceFlag      = kingpin.Flag("trace", "Trace lexer states as they are traversed.").Bool()
 	checkFlag      = kingpin.Flag("check", "Do not format, check for tokenization errors instead.").Bool()
+	filenameFlag   = kingpin.Flag("filename", "Filename to use for selecting a lexer when reading from stdin.").String()
 
 	lexerFlag     = kingpin.Flag("lexer", "Lexer to use when formatting.").PlaceHolder("autodetect").Short('l').Enum(lexers.Names(true)...)
 	styleFlag     = kingpin.Flag("style", "Style to use for formatting.").Short('s').Default("swapoff").Enum(styles.Names()...)
@@ -167,7 +168,7 @@ command, for Go.
 	if len(*filesArgs) == 0 {
 		contents, err := ioutil.ReadAll(os.Stdin)
 		kingpin.FatalIfError(err, "")
-		format(w, style, lex("", string(contents)))
+		format(w, style, lex(*filenameFlag, string(contents)))
 	} else {
 		for _, filename := range *filesArgs {
 			contents, err := ioutil.ReadFile(filename)


### PR DESCRIPTION
cgit's syntax highlighting filter pipes to STDIN and provides the
filename in argv; the analyzer often fails but we have access to the
original filename, so we add an optional argument to specify the
filename to use for matching a lexer when reading from STDIN; when
[files...] are provided to chroma this is completely ignored