### PR TITLE
Fix typo: translater → translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Chroma takes source code and other structured text and converts it into syntax
 highlighted HTML, ANSI-coloured text, etc.
 
 Chroma is based heavily on [Pygments](http://pygments.org/), and includes
-translaters for Pygments lexers and styles.
+translators for Pygments lexers and styles.
 
 ## Table of Contents
 

--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 // Package chroma takes source code and other structured text and converts it into syntax highlighted HTML, ANSI-
 // coloured text, etc.
 //
-// Chroma is based heavily on Pygments, and includes translaters for Pygments lexers and styles.
+// Chroma is based heavily on Pygments, and includes translators for Pygments lexers and styles.
 //
 // For more information, go here: https://github.com/alecthomas/chroma
 package chroma


### PR DESCRIPTION
Just a minor typo that I noticed in the process of packaging chroma for Debian.
Many thanks!