### PR TITLE
go: Fix line comment at end of input

### DIFF
--- a/lexers/go.go
+++ b/lexers/go.go
@@ -19,7 +19,7 @@ var Go = Register(MustNewLexer(
 			{`\n`, Text, nil},
 			{`\s+`, Text, nil},
 			{`\\\n`, Text, nil},
-			{`//(.*?)\n`, CommentSingle, nil},
+			{`//(.*?)$`, CommentSingle, nil},
 			{`/(\\\n)?[*](.|\n)*?[*](\\\n)?/`, CommentMultiline, nil},
 			{`(import|package)\b`, KeywordNamespace, nil},
 			{`(var|func|struct|map|chan|type|interface|const)\b`, KeywordDeclaration, nil},


### PR DESCRIPTION
Chroma's go lexer did not correctly recognise single line comments if they were at the end of the input without a trailing newline. This PR corrects that issue.

While having input that ends without a final newline is not normally the case with source code files, it often occurs when using chroma as a library to highlight code snippets displayed in other tools. In particular, this is the case with [Hugo](https://gohugo.io/). Adding a newline is not a valid workaround, as that can cause dead space to appear below the code snippet.

Given the following input:

    var x = 1 // Comment 1
    var y = 2 // Comment 2<no-new-line>

...output **before** the PR was:
![screenshot from 2018-02-10 22-54-56](https://user-images.githubusercontent.com/798851/36067034-9757e51e-0eb5-11e8-917a-679ffb055605.png)

...and output **after** the PR is:
![screenshot from 2018-02-10 22-54-31](https://user-images.githubusercontent.com/798851/36067036-9cec8552-0eb5-11e8-823e-86a0416b57ad.png)
