### PR TITLE
Avoid adding an HTML prefix to empty class names.

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -241,13 +241,18 @@ func (f *Formatter) shouldHighlight(highlightIndex, line int) (bool, bool) {
 
 func (f *Formatter) class(t chroma.TokenType) string {
 	for t != 0 {
-		cls, ok := chroma.StandardTypes[t]
-		if ok {
-			return f.prefix + cls
+		if cls, ok := chroma.StandardTypes[t]; ok {
+			if cls != "" {
+				return f.prefix + cls
+			}
+			return ""
 		}
 		t = t.Parent()
 	}
-	return f.prefix + chroma.StandardTypes[t]
+	if cls := chroma.StandardTypes[t]; cls != "" {
+		return f.prefix + cls
+	}
+	return ""
 }
 
 func (f *Formatter) styleAttr(styles map[chroma.TokenType]string, tt chroma.TokenType) string {

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -79,15 +79,20 @@ func TestFormatterStyleToCSS(t *testing.T) {
 
 func TestClassPrefix(t *testing.T) {
 	wantPrefix := "some-prefix-"
-	f := New(WithClasses(), ClassPrefix(wantPrefix))
+	withPrefix := New(WithClasses(), ClassPrefix(wantPrefix))
+	noPrefix := New(WithClasses())
 	for st := range chroma.StandardTypes {
-		if got := f.class(st); !strings.HasPrefix(got, wantPrefix) {
-			t.Errorf("f.class(%v): %q should have a class prefix", st, got)
+		if noPrefix.class(st) == "" {
+			if got := withPrefix.class(st); got != "" {
+				t.Errorf("Formatter.class(%v): prefix shouldn't be added to empty classes")
+			}
+		} else if got := withPrefix.class(st); !strings.HasPrefix(got, wantPrefix) {
+			t.Errorf("Formatter.class(%v): %q should have a class prefix", st, got)
 		}
 	}
 
 	var styleBuf bytes.Buffer
-	f.WriteCSS(&styleBuf, styles.Fallback)
+	withPrefix.WriteCSS(&styleBuf, styles.Fallback)
 	if !strings.Contains(styleBuf.String(), ".some-prefix-chroma ") {
 		t.Error("Stylesheets should have a class prefix")
 	}


### PR DESCRIPTION
This makes the raw markup a bit cleaner when there's lots of `Text`
tokens.