### PR TITLE
create plaintext lexer

### DIFF
--- a/lexers/internal/api.go
+++ b/lexers/internal/api.go
@@ -144,13 +144,16 @@ func Register(lexer chroma.Lexer) chroma.Lexer {
 	return lexer
 }
 
-// Fallback lexer if no other is found.
-var Fallback chroma.Lexer = chroma.MustNewLexer(&chroma.Config{
-	Name:      "fallback",
-	Filenames: []string{"*"},
-}, chroma.Rules{
+// Used for the fallback lexer as well as the explicit plaintext lexer
+var PlaintextRules = chroma.Rules{
 	"root": []chroma.Rule{
 		{`.+`, chroma.Text, nil},
 		{`\n`, chroma.Text, nil},
 	},
-})
+}
+
+// Fallback lexer if no other is found.
+var Fallback chroma.Lexer = chroma.MustNewLexer(&chroma.Config{
+	Name:      "fallback",
+	Filenames: []string{"*"},
+}, PlaintextRules)

--- a/lexers/p/plaintext
+++ b/lexers/p/plaintext
@@ -1,0 +1,20 @@
+package p
+
+import (
+	. "github.com/alecthomas/chroma" // nolint
+	"github.com/alecthomas/chroma/lexers/internal"
+)
+
+// Plaintext lexer.
+var Plaintext = internal.Register(MustNewLexer(
+	&Config{
+		Name:      "plaintext",
+		Aliases:   []string{"text", "plain", "no-highlight"},
+		Filenames: []string{"*.txt"},
+		MimeTypes: []string{"text/plain"},
+	},
+	Rules{
+		"root": {
+			{`.*`, Text, nil},
+	},
+))

--- a/lexers/p/plaintext.go
+++ b/lexers/p/plaintext.go
@@ -5,7 +5,6 @@ import (
 	"github.com/alecthomas/chroma/lexers/internal"
 )
 
-// Plaintext lexer.
 var Plaintext = internal.Register(MustNewLexer(
 	&Config{
 		Name:      "plaintext",
@@ -13,8 +12,5 @@ var Plaintext = internal.Register(MustNewLexer(
 		Filenames: []string{"*.txt"},
 		MimeTypes: []string{"text/plain"},
 	},
-	Rules{
-		"root": {
-			{`.*`, Text, nil},
-	},
+	internal.PlaintextRules,
 ))


### PR DESCRIPTION
In Hugo (and probably similar applications), markdown code blocks are always highlighted.
Sometimes users put plaintext in these boxes, so it is useful to have a simple lexer for it. 
This is `no-highlight` in highlight.js.