### PR TITLE
✨ Tool for generating css from styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ All Pygments styles have been converted to Chroma using the `_tools/style.py` sc
 
 For a quick overview of the available styles and how they look, check out the [Chroma Style Gallery](https://xyproto.github.io/splash/docs/).
 
+For standalone usage css styles can be generated using `_tools/style2css/main.go` tool:
+
+```sh
+$ go run _tools/style2css/main.go dracula > dracula.css
+```
+
 ## Command-line interface
 
 A command-line interface to Chroma is included. It can be installed with:

--- a/_tools/style2css/main.go
+++ b/_tools/style2css/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+
+	"github.com/alecthomas/chroma/formatters/html"
+	"github.com/alecthomas/chroma/styles"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
+)
+
+var (
+	nameArg = kingpin.Arg("name", "Name of input style.").Required().Enum(styles.Names()...)
+)
+
+func main() {
+	kingpin.Parse()
+
+	formatter := html.New(html.WithClasses())
+	err := formatter.WriteCSS(os.Stdout, styles.Get("solarized-dark"))
+	kingpin.FatalIfError(err, "")
+}


### PR DESCRIPTION
I'm a user of [Hugo](https://gohugo.io/) static site generator, which is using chroma under the hood. In some cases standalone css styles are required to override highlight theme. I've found [this instruction](https://discourse.gohugo.io/t/converting-pygments-styles-to-chroma/11561) and adopted it to make the process easier. As a result I added a tiny utility for printing out generated css-styles.