### PR TITLE
✨ New styles from solarized styles family

### DIFF
--- a/styles/solarized-dark.go
+++ b/styles/solarized-dark.go
@@ -1,0 +1,46 @@
+package styles
+
+import (
+	"github.com/alecthomas/chroma"
+)
+
+// SolarizedDark style.
+var SolarizedDark = Register(chroma.MustNewStyle("solarized-dark", chroma.StyleEntries{
+	chroma.Keyword:               "#719e07",
+	chroma.KeywordConstant:       "#CB4B16",
+	chroma.KeywordDeclaration:    "#268BD2",
+	chroma.KeywordReserved:       "#268BD2",
+	chroma.KeywordType:           "#DC322F",
+	chroma.NameAttribute:         "#93A1A1",
+	chroma.NameBuiltin:           "#B58900",
+	chroma.NameBuiltinPseudo:     "#268BD2",
+	chroma.NameClass:             "#268BD2",
+	chroma.NameConstant:          "#CB4B16",
+	chroma.NameDecorator:         "#268BD2",
+	chroma.NameEntity:            "#CB4B16",
+	chroma.NameException:         "#CB4B16",
+	chroma.NameFunction:          "#268BD2",
+	chroma.NameTag:               "#268BD2",
+	chroma.NameVariable:          "#268BD2",
+	chroma.LiteralString:         "#2AA198",
+	chroma.LiteralStringBacktick: "#586E75",
+	chroma.LiteralStringChar:     "#2AA198",
+	chroma.LiteralStringDoc:      "#93A1A1",
+	chroma.LiteralStringEscape:   "#CB4B16",
+	chroma.LiteralStringHeredoc:  "#93A1A1",
+	chroma.LiteralStringRegex:    "#DC322F",
+	chroma.LiteralNumber:         "#2AA198",
+	chroma.Operator:              "#719e07",
+	chroma.Comment:               "#586E75",
+	chroma.CommentPreproc:        "#719e07",
+	chroma.CommentSpecial:        "#719e07",
+	chroma.GenericDeleted:        "#DC322F",
+	chroma.GenericEmph:           "italic",
+	chroma.GenericError:          "#DC322F bold",
+	chroma.GenericHeading:        "#CB4B16",
+	chroma.GenericInserted:       "#719e07",
+	chroma.GenericStrong:         "bold",
+	chroma.GenericSubheading:     "#268BD2",
+	chroma.Background:            "#93A1A1 bg:#002B36",
+	chroma.Other:                 "#CB4B16",
+}))

--- a/styles/solarized-dark256.go
+++ b/styles/solarized-dark256.go
@@ -1,0 +1,48 @@
+package styles
+
+import (
+	"github.com/alecthomas/chroma"
+)
+
+// SolarizedDark256 style.
+var SolarizedDark256 = Register(chroma.MustNewStyle("solarized-dark256", chroma.StyleEntries{
+	chroma.Keyword:               "#5f8700",
+	chroma.KeywordConstant:       "#d75f00",
+	chroma.KeywordDeclaration:    "#0087ff",
+	chroma.KeywordNamespace:      "#d75f00",
+	chroma.KeywordReserved:       "#0087ff",
+	chroma.KeywordType:           "#af0000",
+	chroma.NameAttribute:         "#8a8a8a",
+	chroma.NameBuiltin:           "#0087ff",
+	chroma.NameBuiltinPseudo:     "#0087ff",
+	chroma.NameClass:             "#0087ff",
+	chroma.NameConstant:          "#d75f00",
+	chroma.NameDecorator:         "#0087ff",
+	chroma.NameEntity:            "#d75f00",
+	chroma.NameException:         "#af8700",
+	chroma.NameFunction:          "#0087ff",
+	chroma.NameTag:               "#0087ff",
+	chroma.NameVariable:          "#0087ff",
+	chroma.LiteralString:         "#00afaf",
+	chroma.LiteralStringBacktick: "#4e4e4e",
+	chroma.LiteralStringChar:     "#00afaf",
+	chroma.LiteralStringDoc:      "#00afaf",
+	chroma.LiteralStringEscape:   "#af0000",
+	chroma.LiteralStringHeredoc:  "#00afaf",
+	chroma.LiteralStringRegex:    "#af0000",
+	chroma.LiteralNumber:         "#00afaf",
+	chroma.Operator:              "#8a8a8a",
+	chroma.OperatorWord:          "#5f8700",
+	chroma.Comment:               "#4e4e4e",
+	chroma.CommentPreproc:        "#5f8700",
+	chroma.CommentSpecial:        "#5f8700",
+	chroma.GenericDeleted:        "#af0000",
+	chroma.GenericEmph:           "italic",
+	chroma.GenericError:          "#af0000 bold",
+	chroma.GenericHeading:        "#d75f00",
+	chroma.GenericInserted:       "#5f8700",
+	chroma.GenericStrong:         "bold",
+	chroma.GenericSubheading:     "#0087ff",
+	chroma.Background:            "#8a8a8a bg:#1c1c1c",
+	chroma.Other:                 "#d75f00",
+}))

--- a/styles/solarized-light.go
+++ b/styles/solarized-light.go
@@ -1,0 +1,24 @@
+package styles
+
+import (
+	"github.com/alecthomas/chroma"
+)
+
+// SolarizedLight style.
+var SolarizedLight = Register(chroma.MustNewStyle("solarized-light", chroma.StyleEntries{
+	chroma.Text:             "bg: #eee8d5 #586e75",
+	chroma.Keyword:          "#859900",
+	chroma.KeywordConstant:  "bold",
+	chroma.KeywordNamespace: "#dc322f bold",
+	chroma.KeywordType:      "bold",
+	chroma.Name:             "#268bd2",
+	chroma.NameBuiltin:      "#cb4b16",
+	chroma.NameClass:        "#cb4b16",
+	chroma.NameTag:          "bold",
+	chroma.Literal:          "#2aa198",
+	chroma.LiteralNumber:    "bold",
+	chroma.OperatorWord:     "#859900",
+	chroma.Comment:          "#93a1a1 italic",
+	chroma.Generic:          "#d33682",
+	chroma.Background:       " bg:#eee8d5",
+}))


### PR DESCRIPTION
It looks like solarized styles are required by people, for ex: [one](https://discourse.gohugo.io/t/converting-pygments-styles-to-chroma/11561), [two](https://themes.gohugo.io/hugo-octopress/) ↓
> However, Chroma does not support the pygments solarized dark style. It’s added to the CSS instead ...

I also need it for for migration from highlight.js to chroma in [another hugo theme](https://github.com/xianmin/hugo-theme-jane).

I've already got required css styles with tool I proposed in #139, but I think it'd be useful to have solarized themes bundled into chroma itself too.