### PR TITLE
Assign .gl class to GenericUnderline

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -354,6 +354,9 @@ func StyleEntryToCSS(e chroma.StyleEntry) string {
 	if e.Italic == chroma.Yes {
 		styles = append(styles, "font-style: italic")
 	}
+	if e.Underline == chroma.Yes {
+		styles = append(styles, "text-decoration: underline")
+	}
 	return strings.Join(styles, "; ")
 }
 

--- a/styles/autumn.go
+++ b/styles/autumn.go
@@ -37,6 +37,7 @@ var Autumn = Register(chroma.MustNewStyle("autumn", chroma.StyleEntries{
 	chroma.GenericPrompt:       "#555555",
 	chroma.GenericOutput:       "#888888",
 	chroma.GenericTraceback:    "#aa0000",
+	chroma.GenericUnderline:    "underline",
 	chroma.Error:               "#F00 bg:#FAA",
 	chroma.Background:          " bg:#ffffff",
 }))

--- a/styles/borland.go
+++ b/styles/borland.go
@@ -27,6 +27,7 @@ var Borland = Register(chroma.MustNewStyle("borland", chroma.StyleEntries{
 	chroma.GenericPrompt:     "#555555",
 	chroma.GenericOutput:     "#888888",
 	chroma.GenericTraceback:  "#aa0000",
+	chroma.GenericUnderline:  "underline",
 	chroma.Error:             "bg:#e3d2d2 #a61717",
 	chroma.Background:        " bg:#ffffff",
 }))

--- a/styles/colorful.go
+++ b/styles/colorful.go
@@ -53,6 +53,7 @@ var Colorful = Register(chroma.MustNewStyle("colorful", chroma.StyleEntries{
 	chroma.GenericPrompt:         "bold #c65d09",
 	chroma.GenericOutput:         "#888",
 	chroma.GenericTraceback:      "#04D",
+	chroma.GenericUnderline:      "underline",
 	chroma.Error:                 "#F00 bg:#FAA",
 	chroma.Background:            " bg:#ffffff",
 }))

--- a/styles/dracula.go
+++ b/styles/dracula.go
@@ -23,6 +23,7 @@ var Dracula = Register(chroma.MustNewStyle("dracula", chroma.StyleEntries{
 	chroma.GenericStrong:            "#f8f8f2",
 	chroma.GenericSubheading:        "#f8f8f2 bold",
 	chroma.GenericTraceback:         "#f8f8f2",
+	chroma.GenericUnderline:         "underline",
 	chroma.Error:                    "#f8f8f2",
 	chroma.Keyword:                  "#ff79c6",
 	chroma.KeywordConstant:          "#ff79c6",

--- a/styles/emacs.go
+++ b/styles/emacs.go
@@ -45,6 +45,7 @@ var Emacs = Register(chroma.MustNewStyle("emacs", chroma.StyleEntries{
 	chroma.GenericPrompt:         "bold #000080",
 	chroma.GenericOutput:         "#888",
 	chroma.GenericTraceback:      "#04D",
+	chroma.GenericUnderline:      "underline",
 	chroma.Error:                 "border:#FF0000",
 	chroma.Background:            " bg:#f8f8f8",
 }))

--- a/styles/friendly.go
+++ b/styles/friendly.go
@@ -45,6 +45,7 @@ var Friendly = Register(chroma.MustNewStyle("friendly", chroma.StyleEntries{
 	chroma.GenericPrompt:         "bold #c65d09",
 	chroma.GenericOutput:         "#888",
 	chroma.GenericTraceback:      "#04D",
+	chroma.GenericUnderline:      "underline",
 	chroma.Error:                 "border:#FF0000",
 	chroma.Background:            " bg:#f0f0f0",
 }))

--- a/styles/github.go
+++ b/styles/github.go
@@ -22,6 +22,7 @@ var GitHub = Register(chroma.MustNewStyle("github", chroma.StyleEntries{
 	chroma.GenericStrong:        "bold",
 	chroma.GenericSubheading:    "#aaaaaa",
 	chroma.GenericTraceback:     "#aa0000",
+	chroma.GenericUnderline:     "underline",
 	chroma.KeywordType:          "bold #445588",
 	chroma.Keyword:              "bold #000000",
 	chroma.LiteralNumber:        "#009999",

--- a/styles/lovelace.go
+++ b/styles/lovelace.go
@@ -54,6 +54,7 @@ var Lovelace = Register(chroma.MustNewStyle("lovelace", chroma.StyleEntries{
 	chroma.GenericPrompt:          "#444444",
 	chroma.GenericStrong:          "bold",
 	chroma.GenericTraceback:       "#2838b0",
+	chroma.GenericUnderline:       "underline",
 	chroma.Error:                  "bg:#a848a8",
 	chroma.Background:             " bg:#ffffff",
 }))

--- a/styles/manni.go
+++ b/styles/manni.go
@@ -45,6 +45,7 @@ var Manni = Register(chroma.MustNewStyle("manni", chroma.StyleEntries{
 	chroma.GenericPrompt:         "bold #000099",
 	chroma.GenericOutput:         "#AAAAAA",
 	chroma.GenericTraceback:      "#99CC66",
+	chroma.GenericUnderline:      "underline",
 	chroma.Error:                 "bg:#FFAAAA #AA0000",
 	chroma.Background:            " bg:#f0f3f3",
 }))

--- a/styles/murphy.go
+++ b/styles/murphy.go
@@ -53,6 +53,7 @@ var Murphy = Register(chroma.MustNewStyle("murphy", chroma.StyleEntries{
 	chroma.GenericPrompt:         "bold #c65d09",
 	chroma.GenericOutput:         "#888",
 	chroma.GenericTraceback:      "#04D",
+	chroma.GenericUnderline:      "underline",
 	chroma.Error:                 "#F00 bg:#FAA",
 	chroma.Background:            " bg:#ffffff",
 }))

--- a/styles/native.go
+++ b/styles/native.go
@@ -37,5 +37,6 @@ var Native = Register(chroma.MustNewStyle("native", chroma.StyleEntries{
 	chroma.GenericPrompt:      "#aaaaaa",
 	chroma.GenericOutput:      "#cccccc",
 	chroma.GenericTraceback:   "#d22323",
+	chroma.GenericUnderline:   "underline",
 	chroma.Error:              "bg:#e3d2d2 #a61717",
 }))

--- a/styles/pastie.go
+++ b/styles/pastie.go
@@ -46,6 +46,7 @@ var Pastie = Register(chroma.MustNewStyle("pastie", chroma.StyleEntries{
 	chroma.GenericPrompt:         "#555555",
 	chroma.GenericOutput:         "#888888",
 	chroma.GenericTraceback:      "#aa0000",
+	chroma.GenericUnderline:      "underline",
 	chroma.Error:                 "bg:#e3d2d2 #a61717",
 	chroma.Background:            " bg:#ffffff",
 }))

--- a/styles/perldoc.go
+++ b/styles/perldoc.go
@@ -38,6 +38,7 @@ var Perldoc = Register(chroma.MustNewStyle("perldoc", chroma.StyleEntries{
 	chroma.GenericPrompt:        "#555555",
 	chroma.GenericOutput:        "#888888",
 	chroma.GenericTraceback:     "#aa0000",
+	chroma.GenericUnderline:     "underline",
 	chroma.Error:                "bg:#e3d2d2 #a61717",
 	chroma.Background:           " bg:#eeeedd",
 }))

--- a/styles/pygments.go
+++ b/styles/pygments.go
@@ -49,6 +49,7 @@ var Pygments = Register(chroma.MustNewStyle("pygments", map[chroma.TokenType]str
 	chroma.GenericPrompt:     "bold #000080",
 	chroma.GenericOutput:     "#888",
 	chroma.GenericTraceback:  "#04D",
+	chroma.GenericUnderline:  "underline",
 
 	chroma.Error: "border:#FF0000",
 }))

--- a/styles/rainbow_dash.go
+++ b/styles/rainbow_dash.go
@@ -20,6 +20,7 @@ var RainbowDash = Register(chroma.MustNewStyle("rainbow_dash", chroma.StyleEntri
 	chroma.GenericStrong:       "bold",
 	chroma.GenericSubheading:   "bold #2c5dcd",
 	chroma.GenericTraceback:    "#c5060b",
+	chroma.GenericUnderline:    "underline",
 	chroma.Keyword:             "bold #2c5dcd",
 	chroma.KeywordPseudo:       "nobold",
 	chroma.KeywordType:         "#5918bb",

--- a/styles/tango.go
+++ b/styles/tango.go
@@ -74,5 +74,6 @@ var Tango = Register(chroma.MustNewStyle("tango", chroma.StyleEntries{
 	chroma.GenericStrong:            "bold #000000",
 	chroma.GenericSubheading:        "bold #800080",
 	chroma.GenericTraceback:         "bold #a40000",
+	chroma.GenericUnderline:         "underline",
 	chroma.Background:               " bg:#f8f8f8",
 }))

--- a/styles/trac.go
+++ b/styles/trac.go
@@ -36,6 +36,7 @@ var Trac = Register(chroma.MustNewStyle("trac", chroma.StyleEntries{
 	chroma.GenericPrompt:      "#555555",
 	chroma.GenericOutput:      "#888888",
 	chroma.GenericTraceback:   "#aa0000",
+	chroma.GenericUnderline:   "underline",
 	chroma.Error:              "bg:#e3d2d2 #a61717",
 	chroma.Background:         " bg:#ffffff",
 }))

--- a/styles/vim.go
+++ b/styles/vim.go
@@ -31,5 +31,6 @@ var Vim = Register(chroma.MustNewStyle("vim", chroma.StyleEntries{
 	chroma.GenericPrompt:      "bold #000080",
 	chroma.GenericOutput:      "#888",
 	chroma.GenericTraceback:   "#04D",
+	chroma.GenericUnderline:   "underline",
 	chroma.Error:              "border:#FF0000",
 }))

--- a/types.go
+++ b/types.go
@@ -310,6 +310,7 @@ var (
 		GenericStrong:     "gs",
 		GenericSubheading: "gu",
 		GenericTraceback:  "gt",
+		GenericUnderline:  "gl",
 	}
 )
 


### PR DESCRIPTION
'l' in gl is for under(l)ine, as the "gu" class is taken by
GenericSubheading.

As I later discover the `GenericUnderline` type that I requested in https://github.com/alecthomas/chroma/issues/159 is already declared in types.go; just that no CSS class is reserved for it. This PR adds that.

~~Should I simply add `chroma.GenericUnderline:     "underline",` to all the *styles/\*.go* files?~~ No, turns out, I also had to tweak `formatters/html/html.go`.

Fixes https://github.com/alecthomas/chroma/issues/159.