### PR TITLE
Fix error with Bash lexer (issue #168)

### DIFF
--- a/lexers/b/bash.go
+++ b/lexers/b/bash.go
@@ -36,7 +36,7 @@ var Bash = internal.Register(MustNewLexer(
 			{`\b(if|fi|else|while|do|done|for|then|return|function|case|select|continue|until|esac|elif)(\s*)\b`, ByGroups(Keyword, Text), nil},
 			{"\\b(alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|declare|dirs|disown|echo|enable|eval|exec|exit|export|false|fc|fg|getopts|hash|help|history|jobs|kill|let|local|logout|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|time|times|trap|true|type|typeset|ulimit|umask|unalias|unset|wait)(?=[\\s)`])", NameBuiltin, nil},
 			{`\A#!.+\n`, CommentPreproc, nil},
-			{`#.*\n`, CommentSingle, nil},
+			{`#.*\S`, CommentSingle, nil},
 			{`\\[\w\W]`, LiteralStringEscape, nil},
 			{`(\b\w+)(\s*)(\+?=)`, ByGroups(NameVariable, Text, Operator), nil},
 			{`[\[\]{}()=]`, Operator, nil},


### PR DESCRIPTION
This pull request proposes a change to the Bash lexer to fix issue #168 .

Before the fix the bash lexer generated this HTML output:

~~~html
<!DOCTYPE html><html><head><link rel='stylesheet' href='style.css'></head><body><pre class="chroma">
<span class="c1"># Install fish
</span><span class="c1"></span>
brew install fish

<span class="c1"># Add fish to your list of available shells
</span><span class="c1"></span>
<span class="nb">echo</span> <span class="s2">&#34;/usr/local/bin/fish/&#34;</span> <span class="p">|</span> sudo tee -a /etc/shells

<span class="c1"># Make fish the defaul shell
</span><span class="c1"></span>
chsh -s /usr/local/bin/fish

# Restart the terminal to load fish shell</pre></body></html>
~~~

The problem is that the last line (the `#` comment) isn't recognised as a comment.

With the fix in this pull request the output becomes:

~~~html
<!DOCTYPE html><html><head><link rel='stylesheet' href='tradingview.css'></head><body><pre class="chroma">
<span class="c1"># Install fish</span>

brew install fish

<span class="c1"># Add fish to your list of available shells</span>

<span class="nb">echo</span> <span class="s2">&#34;/usr/local/bin/fish/&#34;</span> <span class="p">|</span> sudo tee -a /etc/shells

<span class="c1"># Make fish the defaul shell</span>

chsh -s /usr/local/bin/fish

<span class="c1"># Restart the terminal to load fish shell</span></pre></body></html>
~~~

Now the last line with the comment is recognised as such.

---

Also note that the empty `<span class="c1"></span>` code, that in the original version follows every comment, is now also gone. I see that as an improvement as well.