### PR TITLE
Pass Token around by value instead of pointer

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -259,7 +259,11 @@ func format(w io.Writer, style *chroma.Style, it chroma.Iterator) {
 
 func check(filename string, it chroma.Iterator) {
 	line, col := 1, 0
-	for token := it(); token != nil; token = it() {
+	for {
+		token, ok := it()
+		if !ok {
+			break
+		}
 		if token.Type == chroma.Error {
 			fmt.Printf("%s:%d:%d %q\n", filename, line, col, token.String())
 		}

--- a/coalesce.go
+++ b/coalesce.go
@@ -6,30 +6,38 @@ func Coalesce(lexer Lexer) Lexer { return &coalescer{lexer} }
 type coalescer struct{ Lexer }
 
 func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, error) {
-	var prev *Token
+	var prev Token
+	havePrev := false
 	it, err := d.Lexer.Tokenise(options, text)
 	if err != nil {
 		return nil, err
 	}
-	return func() *Token {
-		for token := it(); token != nil; token = it() {
+	return func() (Token, bool) {
+		for {
+			token, ok := it()
+			if !ok {
+				break
+			}
 			if len(token.Value) == 0 {
 				continue
 			}
-			if prev == nil {
+			if !havePrev {
 				prev = token
+				havePrev = true
 			} else {
 				if prev.Type == token.Type && len(prev.Value) < 8192 {
 					prev.Value += token.Value
 				} else {
 					out := prev
 					prev = token
-					return out
+					return out, true
 				}
 			}
 		}
-		out := prev
-		prev = nil
-		return out
+		if havePrev {
+			havePrev = false
+			return prev, true
+		}
+		return Token{}, false
 	}, nil
 }

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -14,6 +14,6 @@ func TestCoalesce(t *testing.T) {
 	}))
 	actual, err := Tokenise(lexer, nil, "!@#$")
 	assert.NoError(t, err)
-	expected := []*Token{{Punctuation, "!@#$"}}
+	expected := []Token{{Punctuation, "!@#$"}}
 	assert.Equal(t, expected, actual)
 }

--- a/delegate.go
+++ b/delegate.go
@@ -122,7 +122,7 @@ func (d *delegatingLexer) Tokenise(options *TokeniseOptions, text string) (Itera
 	return Literator(out...), nil
 }
 
-func splitToken(t Token, offset int) (r Token, rok bool, l Token, lok bool) {
+func splitToken(t Token, offset int) (l Token, rok bool, r Token, lok bool) {
 	if offset == 0 {
 		return Token{}, false, t, true
 	}
@@ -133,5 +133,5 @@ func splitToken(t Token, offset int) (r Token, rok bool, l Token, lok bool) {
 	r.Type = t.Type
 	l.Value = t.Value[:offset]
 	r.Value = t.Value[offset:]
-	return r, true, l, true
+	return l, true, r, true
 }

--- a/delegate_test.go
+++ b/delegate_test.go
@@ -31,9 +31,9 @@ func TestDelegate(t *testing.T) {
 	testdata := []struct {
 		name     string
 		source   string
-		expected []*Token
+		expected []Token
 	}{
-		{"SourceInMiddle", `hello world <? what ?> there`, []*Token{
+		{"SourceInMiddle", `hello world <? what ?> there`, []Token{
 			{Keyword, "hello"},
 			{TextWhitespace, " "},
 			{Name, "world"},
@@ -48,7 +48,7 @@ func TestDelegate(t *testing.T) {
 			{TextWhitespace, " "},
 			{Name, "there"},
 		}},
-		{"SourceBeginning", `<? what ?> hello world there`, []*Token{
+		{"SourceBeginning", `<? what ?> hello world there`, []Token{
 			{CommentPreproc, "<?"},
 			{TextWhitespace, " "},
 			{Keyword, "what"},
@@ -61,7 +61,7 @@ func TestDelegate(t *testing.T) {
 			{TextWhitespace, " "},
 			{Name, "there"},
 		}},
-		{"SourceEnd", `hello world <? what there`, []*Token{
+		{"SourceEnd", `hello world <? what there`, []Token{
 			{Keyword, "hello"},
 			{TextWhitespace, " "},
 			{Name, "world"},
@@ -73,7 +73,7 @@ func TestDelegate(t *testing.T) {
 			{TextWhitespace, " "},
 			{Error, "there"},
 		}},
-		{"SourceMultiple", "hello world <? what ?> hello there <? what ?> hello", []*Token{
+		{"SourceMultiple", "hello world <? what ?> hello there <? what ?> hello", []Token{
 			{Keyword, "hello"},
 			{TextWhitespace, " "},
 			{Name, "world"},

--- a/formatters/api.go
+++ b/formatters/api.go
@@ -11,12 +11,15 @@ import (
 var (
 	// NoOp formatter.
 	NoOp = Register("noop", chroma.FormatterFunc(func(w io.Writer, s *chroma.Style, iterator chroma.Iterator) error {
-		for t := iterator(); t != nil; t = iterator() {
+		for {
+			t, ok := iterator()
+			if !ok {
+				return nil
+			}
 			if _, err := io.WriteString(w, t.Value); err != nil {
 				return err
 			}
 		}
-		return nil
 	}))
 	// Default HTML formatter outputs self-contained HTML.
 	htmlFull = Register("html", html.New(html.Standalone(), html.WithClasses()))

--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -129,7 +129,7 @@ func (f *Formatter) restyle(style *chroma.Style) (*chroma.Style, error) {
 // We deliberately don't use html/template here because it is two orders of magnitude slower (benchmarked).
 //
 // OTOH we need to be super careful about correct escaping...
-func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []*chroma.Token) (err error) { // nolint: gocyclo
+func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.Token) (err error) { // nolint: gocyclo
 	style, err = f.restyle(style)
 	if err != nil {
 		return err
@@ -391,8 +391,8 @@ func compressStyle(s string) string {
 	return strings.Join(out, ";")
 }
 
-func splitTokensIntoLines(tokens []*chroma.Token) (out [][]*chroma.Token) {
-	line := []*chroma.Token{}
+func splitTokensIntoLines(tokens []chroma.Token) (out [][]chroma.Token) {
+	line := []chroma.Token{}
 	for _, token := range tokens {
 		for strings.Contains(token.Value, "\n") {
 			parts := strings.SplitAfterN(token.Value, "\n", 2)

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -32,11 +32,11 @@ func BenchmarkHTMLFormatter(b *testing.B) {
 }
 
 func TestSplitTokensIntoLines(t *testing.T) {
-	in := []*chroma.Token{
+	in := []chroma.Token{
 		{Value: "hello", Type: chroma.NameKeyword},
 		{Value: " world\nwhat?\n", Type: chroma.NameKeyword},
 	}
-	expected := [][]*chroma.Token{
+	expected := [][]chroma.Token{
 		{
 			{Type: chroma.NameKeyword, Value: "hello"},
 			{Type: chroma.NameKeyword, Value: " world\n"},
@@ -53,7 +53,7 @@ func TestSplitTokensIntoLines(t *testing.T) {
 }
 
 func TestIteratorPanicRecovery(t *testing.T) {
-	it := func() *chroma.Token {
+	it := func() (chroma.Token, bool) {
 		panic(errors.New("bad"))
 	}
 	err := New().Format(ioutil.Discard, styles.Fallback, it)

--- a/formatters/json.go
+++ b/formatters/json.go
@@ -12,7 +12,11 @@ import (
 var JSON = Register("json", chroma.FormatterFunc(func(w io.Writer, s *chroma.Style, it chroma.Iterator) error {
 	fmt.Fprintln(w, "[")
 	i := 0
-	for t := it(); t != nil; t = it() {
+	for {
+		t, ok := it()
+		if !ok {
+			break
+		}
 		if i > 0 {
 			fmt.Fprintln(w, ",")
 		}

--- a/formatters/tokens.go
+++ b/formatters/tokens.go
@@ -9,10 +9,13 @@ import (
 
 // Tokens formatter outputs the raw token structures.
 var Tokens = Register("tokens", chroma.FormatterFunc(func(w io.Writer, s *chroma.Style, it chroma.Iterator) error {
-	for t := it(); t != nil; t = it() {
+	for {
+		t, ok := it()
+		if !ok {
+			return nil
+		}
 		if _, err := fmt.Fprintln(w, t.GoString()); err != nil {
 			return err
 		}
 	}
-	return nil
 }))

--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -216,7 +216,11 @@ func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma
 		}
 	}()
 	theme := styleToEscapeSequence(c.table, style)
-	for token := it(); token != nil; token = it() {
+	for {
+		token, ok := it()
+		if !ok {
+			return nil
+		}
 		// TODO: Cache token lookups?
 		clr, ok := theme[token.Type]
 		if !ok {
@@ -236,7 +240,6 @@ func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma
 			fmt.Fprintf(w, "\033[0m")
 		}
 	}
-	return nil
 }
 
 // TTY8 is an 8-colour terminal formatter.

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -11,7 +11,11 @@ import (
 var TTY16m = Register("terminal16m", chroma.FormatterFunc(trueColourFormatter))
 
 func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
-	for token := it(); token != nil; token = it() {
+	for {
+		token, ok := it()
+		if !ok {
+			return nil
+		}
 		entry := style.Get(token.Type)
 		if !entry.IsZero() {
 			out := ""
@@ -34,5 +38,4 @@ func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) e
 			fmt.Fprint(w, "\033[0m")
 		}
 	}
-	return nil
 }

--- a/lexer.go
+++ b/lexer.go
@@ -66,10 +66,8 @@ type Token struct {
 func (t *Token) String() string   { return t.Value }
 func (t *Token) GoString() string { return fmt.Sprintf("&Token{%s, %q}", t.Type, t.Value) }
 
-func (t *Token) Clone() *Token {
-	clone := &Token{}
-	*clone = *t
-	return clone
+func (t *Token) Clone() Token {
+	return *t
 }
 
 type TokeniseOptions struct {

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -35,7 +35,7 @@ func TestSimpleLexer(t *testing.T) {
 	a = 10
 `)
 	assert.NoError(t, err)
-	expected := []*Token{
+	expected := []Token{
 		{Whitespace, "\n\t"},
 		{Comment, "; this is a comment"},
 		{Whitespace, "\n\t"},

--- a/lexers/lexer_benchmark_test.go
+++ b/lexers/lexer_benchmark_test.go
@@ -32,7 +32,8 @@ func Benchmark(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		it, err := g.Go.Tokenise(nil, lexerBenchSource)
 		assert.NoError(b, err)
-		for t := it(); t != nil; t = it() {
+		if len(it.Tokens()) == 0 {
+			panic("this exists just to try and prevent the compiler from optimizing away the call to Tokens()")
 		}
 	}
 }

--- a/lexers/lexers_test.go
+++ b/lexers/lexers_test.go
@@ -65,7 +65,7 @@ func TestLexers(t *testing.T) {
 			assert.NoError(t, err)
 
 			// Read expected JSON into token slice.
-			expected := []*chroma.Token{}
+			expected := []chroma.Token{}
 			r, err := os.Open(expectedFilename)
 			assert.NoError(t, err)
 			err = json.NewDecoder(r).Decode(&expected)

--- a/lexers/r/rst.go
+++ b/lexers/r/rst.go
@@ -61,7 +61,7 @@ var Restructuredtext = internal.Register(MustNewLexer(
 
 func rstCodeBlock(groups []string, lexer Lexer) Iterator {
 	iterators := []Iterator{}
-	tokens := []*Token{
+	tokens := []Token{
 		{Punctuation, groups[1]},
 		{Text, groups[2]},
 		{OperatorWord, groups[3]},
@@ -73,7 +73,7 @@ func rstCodeBlock(groups []string, lexer Lexer) Iterator {
 	code := strings.Join(groups[8:], "")
 	lexer = internal.Get(groups[6])
 	if lexer == nil {
-		tokens = append(tokens, &Token{String, code})
+		tokens = append(tokens, Token{String, code})
 		iterators = append(iterators, Literator(tokens...))
 	} else {
 		sub, err := lexer.Tokenise(nil, code)

--- a/mutators.go
+++ b/mutators.go
@@ -122,7 +122,7 @@ func Default(mutators ...Mutator) Rule {
 }
 
 // Stringify returns the raw string for a set of tokens.
-func Stringify(tokens ...*Token) string {
+func Stringify(tokens ...Token) string {
 	out := []string{}
 	for _, t := range tokens {
 		out = append(out, t.Value)

--- a/mutators_test.go
+++ b/mutators_test.go
@@ -52,6 +52,6 @@ func TestCombine(t *testing.T) {
 	})
 	it, err := l.Tokenise(nil, "hello world")
 	assert.NoError(t, err)
-	expected := []*Token{{String, `hello`}, {Whitespace, ` `}, {Name, `world`}}
+	expected := []Token{{String, `hello`}, {Whitespace, ` `}, {Name, `world`}}
 	assert.Equal(t, expected, it.Tokens())
 }

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -14,7 +14,7 @@ func TestNewlineAtEndOfFile(t *testing.T) {
 	}))
 	it, err := l.Tokenise(nil, `hello`)
 	assert.NoError(t, err)
-	assert.Equal(t, []*Token{{Keyword, "hello"}, {Whitespace, "\n"}}, it.Tokens())
+	assert.Equal(t, []Token{{Keyword, "hello"}, {Whitespace, "\n"}}, it.Tokens())
 
 	l = Coalesce(MustNewLexer(nil, Rules{
 		"root": {
@@ -23,5 +23,5 @@ func TestNewlineAtEndOfFile(t *testing.T) {
 	}))
 	it, err = l.Tokenise(nil, `hello`)
 	assert.NoError(t, err)
-	assert.Equal(t, []*Token{{Error, "hello"}}, it.Tokens())
+	assert.Equal(t, []Token{{Error, "hello"}}, it.Tokens())
 }

--- a/remap.go
+++ b/remap.go
@@ -2,11 +2,11 @@ package chroma
 
 type remappingLexer struct {
 	lexer  Lexer
-	mapper func(*Token) []*Token
+	mapper func(Token) []Token
 }
 
 // RemappingLexer remaps a token to a set of, potentially empty, tokens.
-func RemappingLexer(lexer Lexer, mapper func(*Token) []*Token) Lexer {
+func RemappingLexer(lexer Lexer, mapper func(Token) []Token) Lexer {
 	return &remappingLexer{lexer, mapper}
 }
 
@@ -19,17 +19,17 @@ func (r *remappingLexer) Tokenise(options *TokeniseOptions, text string) (Iterat
 	if err != nil {
 		return nil, err
 	}
-	buffer := []*Token{}
-	return func() *Token {
+	var buffer []Token
+	return func() (Token, bool) {
 		for {
 			if len(buffer) > 0 {
 				t := buffer[0]
 				buffer = buffer[1:]
-				return t
+				return t, true
 			}
-			t := it()
-			if t == nil {
-				return t
+			t, ok := it()
+			if !ok {
+				return t, ok
 			}
 			buffer = r.mapper(t)
 		}
@@ -67,7 +67,7 @@ func TypeRemappingLexer(lexer Lexer, mapping TypeMapping) Lexer {
 		}
 
 	}
-	return RemappingLexer(lexer, func(t *Token) []*Token {
+	return RemappingLexer(lexer, func(t Token) []Token {
 		if k, ok := lut[t.Type]; ok {
 			if tt, ok := k[t.Value]; ok {
 				t.Type = tt
@@ -75,6 +75,6 @@ func TypeRemappingLexer(lexer Lexer, mapping TypeMapping) Lexer {
 				t.Type = tt
 			}
 		}
-		return []*Token{t}
+		return []Token{t}
 	})
 }

--- a/remap_test.go
+++ b/remap_test.go
@@ -19,7 +19,7 @@ func TestRemappingLexer(t *testing.T) {
 
 	it, err := lexer.Tokenise(nil, `if true then print else end`)
 	assert.NoError(t, err)
-	expected := []*Token{
+	expected := []Token{
 		{Keyword, "if"}, {TextWhitespace, " "}, {Name, "true"}, {TextWhitespace, " "}, {Name, "then"},
 		{TextWhitespace, " "}, {Name, "print"}, {TextWhitespace, " "}, {Keyword, "else"},
 		{TextWhitespace, " "}, {Name, "end"},

--- a/types.go
+++ b/types.go
@@ -341,5 +341,5 @@ func (t TokenType) InSubCategory(other TokenType) bool {
 }
 
 func (t TokenType) Emit(groups []string, lexer Lexer) Iterator {
-	return Literator(&Token{Type: t, Value: groups[0]})
+	return Literator(Token{Type: t, Value: groups[0]})
 }


### PR DESCRIPTION
Hi,

Here's a basic attempt at changing to Token, and changing use of nil token for (Token{}, false).

Sometimes this gets a little clumsy, such as in delegate.go. Probably the code could be improved with a less literal translation, but that's all I had the imagination for at this hour on a Friday night.

The lexer benchmark improves slightly:
Benchmark-20                1000           1237538 ns/op           89612 B/op       1599 allocs/op

vs master:
Benchmark-20                1000           1242267 ns/op           78404 B/op       1723 allocs/op

I feel instinctively that it should be a bigger difference. So I think there's some work to do to figure out where the other allocations are coming from.

What do you think of this direction so far?
