### PR TITLE
Fix YAML pipe symbol (issue #194)

### DIFF
--- a/lexers/y/yaml.go
+++ b/lexers/y/yaml.go
@@ -20,7 +20,7 @@ var YAML = internal.Register(MustNewLexer(
 			{`&[^\s]+`, CommentPreproc, nil},
 			{`\*[^\s]+`, CommentPreproc, nil},
 			{`^%include\s+[^\n\r]+`, CommentPreproc, nil},
-			{`([>|])(\s+)((?:(?:.*?$)(?:[\n\r]*?\2)?)*)`, ByGroups(StringDoc, StringDoc, StringDoc), nil},
+			{`([>|+-]\s+)(\s+)((?:(?:.*?$)(?:[\n\r]*?)?)*)`, ByGroups(StringDoc, StringDoc, StringDoc), nil},
 			Include("value"),
 			{`[?:,\[\]]`, Punctuation, nil},
 			{`.`, Text, nil},


### PR DESCRIPTION
This pull request fixes the issue reported with the pipe symbol (`|`) in #194 . 

Since `|` can signal a multi-line string (or scalar block as YAML calls it) besides appearing regular in strings, this pull request proposes to only consider it a string when `|` marks the end of the line (or, put differently, the start of a scalar block).

Before:

![2018-11-12_07-06-12](https://user-images.githubusercontent.com/13403160/48330457-e6453b80-e64c-11e8-8dd4-cecabf2a2df6.png)

After:

![2018-11-12_07-26-38](https://user-images.githubusercontent.com/13403160/48330467-eb09ef80-e64c-11e8-92bc-f12d0c5acf41.png)



