### PR TITLE
Wrapped line numbers in anchor tags for line specific external links.

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -175,7 +175,7 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 				fmt.Fprintf(w, "<span%s>", f.styleAttr(css, chroma.LineHighlight))
 			}
 
-			fmt.Fprintf(w, "<a class=\"ln\" href=\"#n%d\" id=\"n%d\" %s>%*d\n</a>", line, line, f.styleAttr(css, chroma.LineNumbersTable), lineDigits, line)
+			fmt.Fprintf(w, "<a href=\"#n%d\" id=\"n%d\"%s>%*d\n</a>", line, line, f.styleAttr(css, chroma.LineNumbersTable), lineDigits, line)
 
 			if highlight {
 				fmt.Fprintf(w, "</span>")

--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -175,7 +175,7 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 				fmt.Fprintf(w, "<span%s>", f.styleAttr(css, chroma.LineHighlight))
 			}
 
-			fmt.Fprintf(w, "<span%s>%*d\n</span>", f.styleAttr(css, chroma.LineNumbersTable), lineDigits, line)
+			fmt.Fprintf(w, "<a class=\"ln\" href=\"#n%d\" id=\"n%d\" %s>%*d\n</a>", line, line, f.styleAttr(css, chroma.LineNumbersTable), lineDigits, line)
 
 			if highlight {
 				fmt.Fprintf(w, "</span>")

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -111,8 +111,8 @@ func TestTableLineNumberNewlines(t *testing.T) {
 	// in a <pre>-friendly format.
 	// Note: placing the newlines inside the <span> lets browser selections look
 	// better, instead of "skipping" over the span margin.
-	assert.Contains(t, buf.String(), `<span class="lnt">2
-</span><span class="lnt">3
-</span><span class="lnt">4
-</span>`)
+	assert.Contains(t, buf.String(), `<a href="#n2" id="n2" class="lnt">2
+</a><a href="#n3" id="n3" class="lnt">3
+</a><a href="#n4" id="n4" class="lnt">4
+</a>`)
 }


### PR DESCRIPTION
@alecthomas I've added line anchors similar to github / cgit to the HTML output.  
E. g. If you want to jump to line 42 append the fragment `#n42` to the URL. 
This resolves #132. Cheers Ruben