### PR TITLE
always surround by span

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -201,6 +201,8 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 		}
 		if highlight {
 			fmt.Fprintf(w, "<span%s>", f.styleAttr(css, chroma.LineHighlight))
+		} else {
+			fmt.Fprintf(w, "<span>")
 		}
 
 		if f.lineNumbers && !wrapInTable {
@@ -215,9 +217,7 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 			}
 			fmt.Fprint(w, html)
 		}
-		if highlight {
-			fmt.Fprintf(w, "</span>")
-		}
+		fmt.Fprintf(w, "</span>")
 	}
 
 	if !f.preventSurroundingPre {

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -116,3 +116,16 @@ func TestTableLineNumberNewlines(t *testing.T) {
 </span><span class="lnt">4
 </span>`)
 }
+
+func TestWriteHTMLStartWithLF(t *testing.T) {
+	f := New(WithClasses(), WithLineNumbers())
+	it, err := lexers.Get("go").Tokenise(nil, "\npackage main")
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = f.Format(&buf, styles.Fallback, it)
+	assert.NoError(t, err)
+	// expect 2 lines
+	assert.Equal(t, buf.String(), `<pre class="chroma"><span><span class="ln">1</span>
+</span><span><span class="ln">2</span><span class="kn">package</span> <span class="nx">main</span></span></pre>`)
+}


### PR DESCRIPTION
Outputs should always be surround by span . Code starting with '\n' may cause line number mismatch . 