### PR TITLE
Fix: recognise comments in end of code snippet (C#)

### DIFF
--- a/lexers/c/csharp.go
+++ b/lexers/c/csharp.go
@@ -20,6 +20,7 @@ var CSharp = internal.Register(MustNewLexer(
 			{`[^\S\n]+`, Text, nil},
 			{`\\\n`, Text, nil},
 			{`//.*?\n`, CommentSingle, nil},
+			{`//.*?$`, CommentSingle, nil},
 			{`/[*].*?[*]/`, CommentMultiline, nil},
 			{`\n`, Text, nil},
 			{`[~!%^&*()+=|\[\]:;,.<>/?-]`, Punctuation, nil},

--- a/lexers/testdata/csharp.actual
+++ b/lexers/testdata/csharp.actual
@@ -9,3 +9,6 @@ foreach (DriveInfo drive in drives)
     Console.WriteLine(dir);
   }
 }
+
+if (BooleanExpression)
+    // Code to execute when the Boolean expression is `true`

--- a/lexers/testdata/csharp.expected
+++ b/lexers/testdata/csharp.expected
@@ -69,5 +69,12 @@
   {"type":"Punctuation","value":"}"},
   {"type":"Text","value":"\n"},
   {"type":"Punctuation","value":"}"},
-  {"type":"Text","value":"\n"}
+  {"type":"Text","value":"\n"},
+  {"type":"Keyword","value":"if"},
+  {"type":"Text","value":" "},
+  {"type":"Punctuation","value":"("},
+  {"type":"Name","value":"BooleanExpression"},
+  {"type":"Punctuation","value":")"},
+  {"type":"Text","value":"\n    "},
+  {"type":"CommentSingle","value":"// Code to execute when the Boolean expression is `true`"}
 ]

--- a/lexers/testdata/csharp.expected
+++ b/lexers/testdata/csharp.expected
@@ -69,7 +69,7 @@
   {"type":"Punctuation","value":"}"},
   {"type":"Text","value":"\n"},
   {"type":"Punctuation","value":"}"},
-  {"type":"Text","value":"\n"},
+  {"type":"Text","value":"\n\n"},
   {"type":"Keyword","value":"if"},
   {"type":"Text","value":" "},
   {"type":"Punctuation","value":"("},


### PR DESCRIPTION
I noticed that, when a highlighted C# snippet ends with a comment, that comment is not recognised. This is caused by the lexer requiring a end of line (`\n`) after a comment. 

While that works fine for regular program code, when we highlight code snippets that are part of a bigger program, a comment at the end often helps to put thing into perspective. (And so should be recognised.)

This pull request does:

- Add comment highlight in the C# lexer for when the code ends with a comment.
- Update the C# test data with a comment in the end.
- Update the expected test data.

## Before
(blue = comment)

![before-example](https://user-images.githubusercontent.com/13403160/51125678-735d6a00-1821-11e9-80d4-7e1cb594705d.png)

## After this pull request
![after-example](https://user-images.githubusercontent.com/13403160/51125691-79ebe180-1821-11e9-862e-a0d60a0bcc1d.png)

---

Let me know if something can be done better or prefer a different way.

Thanks for your consideration. :slightly_smiling_face: 