### PR TITLE
Fix: recognise end comment in TradingView lexer

### DIFF
--- a/lexers/t/tradingview.go
+++ b/lexers/t/tradingview.go
@@ -17,7 +17,7 @@ var TradingView = internal.Register(MustNewLexer(
 	Rules{
 		"root": {
 			{`[^\S\n]+|\n|[()]`, Text, nil},
-			{`(//.*?)(\n)`, ByGroups(CommentSingle, Text), nil},
+			{`//.*?$`, CommentSingle, nil},
 			{`>=|<=|==|!=|>|<|\?|-|\+|\*|\/|%|\[|\]`, Operator, nil},
 			{`[:,.]`, Punctuation, nil},
 			{`=`, KeywordPseudo, nil},

--- a/lexers/testdata/tradingview.actual
+++ b/lexers/testdata/tradingview.actual
@@ -10,3 +10,5 @@ plot(series=emaVal, style=circles, offset=2, linewidth=3)
 bgcolor(color=close > open ? orange :
      close != high[1] ? purple :
      na, transp=80)
+
+// Comment as last line should be recognised too

--- a/lexers/testdata/tradingview.expected
+++ b/lexers/testdata/tradingview.expected
@@ -89,5 +89,6 @@
   {"type":"Text","value":", transp"},
   {"type":"KeywordPseudo","value":"="},
   {"type":"LiteralNumber","value":"80"},
-  {"type":"Text","value":")\n"}
+  {"type":"Text","value":")\n\n"},
+  {"type":"CommentSingle","value":"// Comment as last line should be recognised too"}
 ]


### PR DESCRIPTION
I noticed that the TradingView lexer does not recognise a comment when a code snippet ends with a comment.

The cause for that is a requirement in the lexer that there should be a newline (`\n`) after a comment. That applies to all comments, except the last one in a code highlight.

This pull request:

- Changes the lexer so that the newline requirement is dropped.
- Adds an example comment as the last line in the testdata.
- Updates the expected outcome of the testdata.

## Before
(blue = comment)

![before-example](https://user-images.githubusercontent.com/13403160/51189839-29d45400-18e1-11e9-96b0-03148fe22efe.png)

## After this pull request

![after-example](https://user-images.githubusercontent.com/13403160/51189850-3193f880-18e1-11e9-84ad-4ed5923ddf73.png)

----

Let me know if you have any feedback or preferred changes.

Thanks for considering this pull request. :slightly_smiling_face: 