### PR TITLE
[WIP] Enable EnsureNL for TradingView and C# lexers

### DIFF
--- a/lexers/c/csharp.go
+++ b/lexers/c/csharp.go
@@ -13,6 +13,7 @@ var CSharp = internal.Register(MustNewLexer(
 		Filenames: []string{"*.cs"},
 		MimeTypes: []string{"text/x-csharp"},
 		DotAll:    true,
+		EnsureNL:  true,
 	},
 	Rules{
 		"root": {

--- a/lexers/t/tradingview.go
+++ b/lexers/t/tradingview.go
@@ -13,6 +13,7 @@ var TradingView = internal.Register(MustNewLexer(
 		Filenames: []string{"*.tv"},
 		MimeTypes: []string{"text/x-tradingview"},
 		DotAll:    true,
+		EnsureNL:  true,
 	},
 	Rules{
 		"root": {

--- a/lexers/testdata/csharp.actual
+++ b/lexers/testdata/csharp.actual
@@ -9,3 +9,5 @@ foreach (DriveInfo drive in drives)
     Console.WriteLine(dir);
   }
 }
+
+// Comment as last line should be recognised properly

--- a/lexers/testdata/csharp.expected
+++ b/lexers/testdata/csharp.expected
@@ -69,5 +69,6 @@
   {"type":"Punctuation","value":"}"},
   {"type":"Text","value":"\n"},
   {"type":"Punctuation","value":"}"},
-  {"type":"Text","value":"\n"}
+  {"type":"Text","value":"\n\n"},
+  {"type":"CommentSingle","value":"// Comment as last line should be recognised properly\n"}
 ]

--- a/lexers/testdata/tradingview.actual
+++ b/lexers/testdata/tradingview.actual
@@ -10,3 +10,5 @@ plot(series=emaVal, style=circles, offset=2, linewidth=3)
 bgcolor(color=close > open ? orange :
      close != high[1] ? purple :
      na, transp=80)
+
+// Comment as last line should be recognised properly

--- a/lexers/testdata/tradingview.expected
+++ b/lexers/testdata/tradingview.expected
@@ -89,5 +89,7 @@
   {"type":"Text","value":", transp"},
   {"type":"KeywordPseudo","value":"="},
   {"type":"LiteralNumber","value":"80"},
-  {"type":"Text","value":")\n"}
+  {"type":"Text","value":")\n\n"},
+  {"type":"CommentSingle","value":"// Comment as last line should be recognised properly"},
+  {"type":"Text","value":"\n"}
 ]


### PR DESCRIPTION
This pull request:

- Enables the `EnsureNL` option for the TradingView and C# lexer. This way when a comment is the last line of a code snippet, that comment gets highlighted properly.
- Adds a test comment as last line to the TradingView and C# testdata files.
- Updates the expected output of those two testdata files.

However, I marked this pull request as 'Work in progress' because I see in the rendered testdata that there's a new line (`\n`) added to the end of the testdata output. I don't know enough about how Chroma operates to interpret that this means that the *'add a complete new line to highlighted blocks'* issue [mentioned earlier](https://github.com/alecthomas/chroma/pull/215#issuecomment-455104348) still applies.

This pull request, when successful, closes #214 and #215.