### PR TITLE
Add additional information about style to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ Chroma styles use the [same syntax](http://pygments.org/docs/styles/) as Pygment
 
 All Pygments styles have been converted to Chroma using the `_tools/style.py` script.
 
+When you work with one of [Chroma's styles](https://github.com/alecthomas/chroma/tree/master/styles), know that the `chroma.Background` token type provides the default style for tokens. It does so by defining a foreground color and background color. 
+
+For example, this gives each token name not defined in the style a default color of `#f8f8f8` and uses `#000000` for the highlighted code block's background:
+
+~~~go
+chroma.Background: "#f8f8f2 bg:#000000",
+~~~
+
+Also, token types in a style file are hierarchical. For instance, when `CommentSpecial` is not defined, Chroma uses the token style from `Comment`. So when several comment tokens use the same color, you'll only need to define `Comment` and override the one that has a different color.
+
 For a quick overview of the available styles and how they look, check out the [Chroma Style Gallery](https://xyproto.github.io/splash/docs/).
 
 ## Command-line interface


### PR DESCRIPTION
When we discussed a recent pull request (#219), it came up that `chroma.Background` defines the default token style. And that tokens in a style file are hierarchical.

This pull request adds that information to the README file to clarify this for others. And to save explaining the same thing in the future again.