### PR TITLE
Fix JS second part of division expression

### DIFF
--- a/lexers/j/javascript.go
+++ b/lexers/j/javascript.go
@@ -23,7 +23,6 @@ var JavascriptRules = Rules{
 	},
 	"root": {
 		{`\A#! ?/.*?\n`, CommentHashbang, nil},
-		{`^(?=\s|/|<!--)`, Text, Push("slashstartsregex")},
 		Include("commentsandwhitespace"),
 		{`(\.\d+|[0-9]+\.[0-9]*)([eE][-+]?[0-9]+)?`, LiteralNumberFloat, nil},
 		{`0[bB][01]+`, LiteralNumberBin, nil},
@@ -32,6 +31,7 @@ var JavascriptRules = Rules{
 		{`[0-9]+`, LiteralNumberInteger, nil},
 		{`\.\.\.|=>`, Punctuation, nil},
 		{`\+\+|--|~|&&|\?|:|\|\||\\(?=\n)|(<<|>>>?|==?|!=?|[-<>+*%&|^/])=?`, Operator, Push("slashstartsregex")},
+		{`^(?=\s|/|<!--)`, Text, Push("slashstartsregex")},
 		{`[{(\[;,]`, Punctuation, Push("slashstartsregex")},
 		{`[})\].]`, Punctuation, nil},
 		{`(for|in|while|do|break|return|continue|switch|case|default|if|else|throw|try|catch|finally|new|delete|typeof|instanceof|void|yield|this|of|class|const|debugger|export|extends|import|super)\b`, Keyword, Push("slashstartsregex")},


### PR DESCRIPTION
This pull request makes a small change to the JavaScript lexer to not recognise the second part of a division as a regex start.

Big thanks to @davidfeng88 who in [his earlier comment](https://github.com/alecthomas/chroma/issues/125#issuecomment-455902797) identified what caused the problem. That made it much easier for me to make the necessary adjustment.

----

I took the liberty to open this pull request since I don't know if David wanted to open a PR for this issue. It was his find after all, so he should deserve the credit. 

But since his comment was almost 2 weeks ago, I thought this pull request was appropriate. If he want to propose his own PR, feel free to discard mine!

## Before this pull request

![before-example](https://user-images.githubusercontent.com/13403160/52161241-95306b00-26c2-11e9-8755-ab5f03412f8d.png)

## After this pull request

![after-example](https://user-images.githubusercontent.com/13403160/52161243-9a8db580-26c2-11e9-92b5-e1e4f7c4f1d9.png)

----

Closes #125.