### PR TITLE
Removed # as a comment character from Prolog lexer

### DIFF
--- a/lexers/p/prolog.go
+++ b/lexers/p/prolog.go
@@ -15,7 +15,6 @@ var Prolog = internal.Register(MustNewLexer(
 	},
 	Rules{
 		"root": {
-			{`^#.*`, CommentSingle, nil},
 			{`/\*`, CommentMultiline, Push("nested-comment")},
 			{`%.*`, CommentSingle, nil},
 			{`0\'.`, LiteralStringChar, nil},


### PR DESCRIPTION
Inline comments are % in Prolog as on old Line 20, not #. Also raised an issue in Pygments.