### PR TITLE
Add EnsureNL in TypeScript lexer config

### DIFF
--- a/lexers/t/typescript.go
+++ b/lexers/t/typescript.go
@@ -13,6 +13,7 @@ var TypeScript = internal.Register(MustNewLexer(
 		Filenames: []string{"*.ts", "*.tsx"},
 		MimeTypes: []string{"text/x-typescript"},
 		DotAll:    true,
+		EnsureNL:  true,
 	},
 	Rules{
 		"commentsandwhitespace": {


### PR DESCRIPTION
Fixes #267 

Add `EnsureNL:  true` in TypeScript lexer config as JavaScript has.
