### PR TITLE
Use `chroma.StyleEntries` instead of map

### DIFF
--- a/styles/pygments.go
+++ b/styles/pygments.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Pygments default theme.
-var Pygments = Register(chroma.MustNewStyle("pygments", map[chroma.TokenType]string{
+var Pygments = Register(chroma.MustNewStyle("pygments", chroma.StyleEntries{
 	chroma.Whitespace:     "#bbbbbb",
 	chroma.Comment:        "italic #408080",
 	chroma.CommentPreproc: "noitalic #BC7A00",

--- a/styles/swapoff.go
+++ b/styles/swapoff.go
@@ -5,7 +5,7 @@ import (
 )
 
 // SwapOff theme.
-var SwapOff = Register(chroma.MustNewStyle("swapoff", map[chroma.TokenType]string{
+var SwapOff = Register(chroma.MustNewStyle("swapoff", chroma.StyleEntries{
 	chroma.Background:        "#lightgray bg:#black",
 	chroma.Number:            "bold #ansiyellow",
 	chroma.Comment:           "#ansiteal",


### PR DESCRIPTION
I've notices `type StyleEntries` is not used at some styles. For consistency with other styles, I've changed `map[chroma.TokenType]string` to `chroma.StyleEntries`.