### PR TITLE
Add italics support for truecolour terminals

### DIFF
--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -174,6 +174,9 @@ func entryToEscapeSequence(table *ttyTable, entry chroma.StyleEntry) string {
 	if entry.Underline == chroma.Yes {
 		out += "\033[4m"
 	}
+	if entry.Italic == chroma.Yes {
+		out += "\033[3m"
+	}
 	if entry.Colour.IsSet() {
 		out += table.foreground[findClosest(table, entry.Colour)]
 	}

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -21,6 +21,9 @@ func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) e
 			if entry.Underline == chroma.Yes {
 				out += "\033[4m"
 			}
+			if entry.Italic == chroma.Yes {
+				out += "\033[3m"
+			}
 			if entry.Colour.IsSet() {
 				out += fmt.Sprintf("\033[38;2;%d;%d;%dm", entry.Colour.Red(), entry.Colour.Green(), entry.Colour.Blue())
 			}


### PR DESCRIPTION
This PR is a bit of a request for feedback. I made the smallest change to support my use-case
for emitting italics, namely limiting it to terminals which claim to support truecolour.

It's possible this change should be replicated in tty_indexed.go as well. (Perhaps some indexed color terminal emulators support italics?) I'm happy to add that change if that's preferred, but I don't have an example emulator to point to where that's true.

Below is a screenshot with the change in iTerm2 and Source Code Pro, showing `go doc ioutil | chroma -f terminal16m -s algol`

<img width="705" alt="Screen Shot 2019-09-01 at 12 21 36 PM" src="https://user-images.githubusercontent.com/715888/64081631-89d50a80-ccb8-11e9-968e-a64605a5f652.png">
