### PR TITLE
Add multi-line comments to Nim lexer

### DIFF
--- a/lexers/n/nim.go
+++ b/lexers/n/nim.go
@@ -16,6 +16,7 @@ var Nim = internal.Register(MustNewLexer(
 	},
 	Rules{
 		"root": {
+			{`#\[[\s\S]*?\]#`, CommentMultiline, nil},
 			{`##.*$`, LiteralStringDoc, nil},
 			{`#.*$`, Comment, nil},
 			{`[*=><+\-/@$~&%!?|\\\[\]]`, Operator, nil},


### PR DESCRIPTION
This pull request adds a multi-line comment rule to the Nim lexer, as requested in #284.

### Before
![2019-09-25_17-12-29](https://user-images.githubusercontent.com/13403160/65616002-96e4d100-dfba-11e9-9310-33a267816a6e.png)

### After this pull request
![2019-09-25_17-25-13](https://user-images.githubusercontent.com/13403160/65616012-99dfc180-dfba-11e9-98e9-3ab27861913a.png)

---

I ran the tests locally, and the Nim test data remained the same. That's why this pull request doesn't change the test data.

Closes #284 