### PR TITLE
Add bool argument to WithClasses, WithLineNumbers etc.

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -139,7 +139,7 @@ func main() {
 
 	// Dump styles.
 	if cli.HTMLStyles {
-		formatter := html.New(html.WithClasses())
+		formatter := html.New(html.WithClasses(true))
 		err = formatter.WriteCSS(w, style)
 		ctx.FatalIfErrorf(err)
 		return
@@ -174,19 +174,19 @@ func configureHTMLFormatter(ctx *kong.Context) {
 		options = append(options, html.ClassPrefix(cli.HTMLPrefix))
 	}
 	if !cli.HTMLInlineStyles {
-		options = append(options, html.WithClasses())
+		options = append(options, html.WithClasses(true))
 	}
 	if !cli.HTMLOnly {
-		options = append(options, html.Standalone())
+		options = append(options, html.Standalone(true))
 	}
 	if cli.HTMLLines {
-		options = append(options, html.WithLineNumbers())
+		options = append(options, html.WithLineNumbers(true))
 	}
 	if cli.HTMLLinesTable {
-		options = append(options, html.LineNumbersInTable())
+		options = append(options, html.LineNumbersInTable(true))
 	}
 	if cli.HTMLPreventSurroundingPre {
-		options = append(options, html.PreventSurroundingPre())
+		options = append(options, html.PreventSurroundingPre(true))
 	}
 	if len(cli.HTMLHighlight) > 0 {
 		ranges := [][2]int{}

--- a/cmd/chromad/main.go
+++ b/cmd/chromad/main.go
@@ -102,7 +102,7 @@ func render(req *renderRequest) (*renderResponse, error) {
 	buf := &strings.Builder{}
 	options := []html.Option{}
 	if req.Classes {
-		options = append(options, html.WithClasses(), html.Standalone())
+		options = append(options, html.WithClasses(true), html.Standalone(true))
 	}
 	formatter := html.New(options...)
 	err = formatter.Format(buf, style, tokens)

--- a/formatters/api.go
+++ b/formatters/api.go
@@ -20,7 +20,7 @@ var (
 		return nil
 	}))
 	// Default HTML formatter outputs self-contained HTML.
-	htmlFull = Register("html", html.New(html.Standalone(), html.WithClasses())) // nolint
+	htmlFull = Register("html", html.New(html.Standalone(true), html.WithClasses(true))) // nolint
 	SVG      = Register("svg", svg.New(svg.EmbedFont("Liberation Mono", svg.FontLiberationMono, svg.WOFF)))
 )
 

--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -14,21 +14,25 @@ import (
 type Option func(f *Formatter)
 
 // Standalone configures the HTML formatter for generating a standalone HTML document.
-func Standalone() Option { return func(f *Formatter) { f.standalone = true } }
+func Standalone(b bool) Option { return func(f *Formatter) { f.standalone = b } }
 
 // ClassPrefix sets the CSS class prefix.
 func ClassPrefix(prefix string) Option { return func(f *Formatter) { f.prefix = prefix } }
 
 // WithClasses emits HTML using CSS classes, rather than inline styles.
-func WithClasses() Option { return func(f *Formatter) { f.Classes = true } }
+func WithClasses(b bool) Option { return func(f *Formatter) { f.Classes = b } }
 
 // TabWidth sets the number of characters for a tab. Defaults to 8.
 func TabWidth(width int) Option { return func(f *Formatter) { f.tabWidth = width } }
 
-// PreventSurroundingPre prevents the surrounding pre tags around the generated code
-func PreventSurroundingPre() Option {
+// PreventSurroundingPre prevents the surrounding pre tags around the generated code.
+func PreventSurroundingPre(b bool) Option {
 	return func(f *Formatter) {
-		f.preWrapper = nopPreWrapper
+		if b {
+			f.preWrapper = nopPreWrapper
+		} else {
+			f.preWrapper = defaultPreWrapper
+		}
 	}
 }
 
@@ -40,17 +44,17 @@ func WithPreWrapper(wrapper PreWrapper) Option {
 }
 
 // WithLineNumbers formats output with line numbers.
-func WithLineNumbers() Option {
+func WithLineNumbers(b bool) Option {
 	return func(f *Formatter) {
-		f.lineNumbers = true
+		f.lineNumbers = b
 	}
 }
 
 // LineNumbersInTable will, when combined with WithLineNumbers, separate the line numbers
 // and code in table td's, which make them copy-and-paste friendly.
-func LineNumbersInTable() Option {
+func LineNumbersInTable(b bool) Option {
 	return func(f *Formatter) {
-		f.lineNumbersInTable = true
+		f.lineNumbersInTable = b
 	}
 }
 


### PR DESCRIPTION
This allows the boolean options to be reconfigured, e.g:

```go
options := getOptions()
options = append(options, html.WithLineNumbers(true))
```

Fixes #301