### PR TITLE
Avoid empty matches in MLIR lexer

### DIFF
--- a/lexers/m/mlir.go
+++ b/lexers/m/mlir.go
@@ -27,7 +27,7 @@ var Mlir = internal.Register(MustNewLexer(
 			{`0[xX][a-fA-F0-9]+`, LiteralNumber, nil},
 			{`-?\d+(?:[.]\d+)?(?:[eE][-+]?\d+(?:[.]\d+)?)?`, LiteralNumber, nil},
 			{`[=<>{}\[\]()*.,!:]|x\b`, Punctuation, nil},
-			{`[\w\d]*`, Text, nil},
+			{`[\w\d]+`, Text, nil},
 		},
 		"whitespace": {
 			{`(\n|\s)+`, Text, nil},


### PR DESCRIPTION
Ensure at least one character is matched else lexing ends up making no forward progress.