### PR TITLE
Highlight the line number targeted by the URL anchor

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -345,6 +345,13 @@ func (f *Formatter) WriteCSS(w io.Writer, style *chroma.Style) error {
 			return err
 		}
 	}
+	// Special-case line number highlighting when targeted.
+	if f.lineNumbers || f.lineNumbersInTable {
+		targetedLineCSS := StyleEntryToCSS(style.Get(chroma.LineHighlight))
+		for _, tt := range []chroma.TokenType{chroma.LineNumbers, chroma.LineNumbersTable} {
+			fmt.Fprintf(w, "/* %s targeted by URL anchor */ .%schroma .%s:target { %s }\n", tt, f.prefix, f.class(tt), targetedLineCSS)
+		}
+	}
 	tts := []int{}
 	for tt := range css {
 		tts = append(tts, int(tt))


### PR DESCRIPTION
This currently works only when `html.WithClasses(true)` is used.
The same colors as for the pre-highlighted lines are used.
Only the line number is highlighted, so difficult to notice, but
better than nothing.