### PR TITLE
Add new TokeniseOption EnsureLF

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -6,7 +6,8 @@ import (
 
 var (
 	defaultOptions = &TokeniseOptions{
-		State: "root",
+		State:    "root",
+		EnsureLF: true,
 	}
 )
 
@@ -80,6 +81,10 @@ type TokeniseOptions struct {
 	State string
 	// Nested tokenisation.
 	Nested bool
+
+	// If true, all EOLs are converted into LF
+	// by replacing CRLF and CR
+	EnsureLF bool
 }
 
 // A Lexer for tokenising source code.

--- a/regexp.go
+++ b/regexp.go
@@ -410,6 +410,10 @@ func (r *RegexLexer) Tokenise(options *TokeniseOptions, text string) (Iterator, 
 	if options == nil {
 		options = defaultOptions
 	}
+	if options.EnsureLF {
+		text = strings.ReplaceAll(text, "\r\n", "\n")
+		text = strings.ReplaceAll(text, "\r", "\n")
+	}
 	if !options.Nested && r.config.EnsureNL && !strings.HasSuffix(text, "\n") {
 		text += "\n"
 	}

--- a/regexp.go
+++ b/regexp.go
@@ -411,8 +411,7 @@ func (r *RegexLexer) Tokenise(options *TokeniseOptions, text string) (Iterator, 
 		options = defaultOptions
 	}
 	if options.EnsureLF {
-		text = strings.ReplaceAll(text, "\r\n", "\n")
-		text = strings.ReplaceAll(text, "\r", "\n")
+		text = ensureLF(text)
 	}
 	if !options.Nested && r.config.EnsureNL && !strings.HasSuffix(text, "\n") {
 		text += "\n"
@@ -440,4 +439,23 @@ func matchRules(text []rune, pos int, rules []*CompiledRule) (int, *CompiledRule
 		}
 	}
 	return 0, &CompiledRule{}, nil
+}
+
+// replace \r and \r\n with \n
+// same as strings.ReplaceAll but more efficient
+func ensureLF(text string) string {
+	buf := make([]byte, len(text))
+	var j int
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		if c == '\r' {
+			if i < len(text)-1 && text[i+1] == '\n' {
+				continue
+			}
+			c = '\n'
+		}
+		buf[j] = c
+		j++
+	}
+	return string(buf[:j])
 }

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -44,7 +44,7 @@ func TestMatchingAtStart(t *testing.T) {
 		it.Tokens())
 }
 
-func TestEnsureLF(t *testing.T) {
+func TestEnsureLFOption(t *testing.T) {
 	l := Coalesce(MustNewLexer(&Config{}, Rules{
 		"root": {
 			{`(\w+)(\r?\n|\r)`, ByGroups(Keyword, Whitespace), nil},
@@ -78,4 +78,24 @@ func TestEnsureLF(t *testing.T) {
 		{Keyword, "world"},
 		{Whitespace, "\r"},
 	}, it.Tokens())
+}
+
+func TestEnsureLFFunc(t *testing.T) {
+	tests := []struct{ in, out string }{
+		{in: "", out: ""},
+		{in: "abc", out: "abc"},
+		{in: "\r", out: "\n"},
+		{in: "a\r", out: "a\n"},
+		{in: "\rb", out: "\nb"},
+		{in: "a\rb", out: "a\nb"},
+		{in: "\r\n", out: "\n"},
+		{in: "a\r\n", out: "a\n"},
+		{in: "\r\nb", out: "\nb"},
+		{in: "a\r\nb", out: "a\nb"},
+		{in: "\r\r\r\n\r", out: "\n\n\n\n"},
+	}
+	for _, test := range tests {
+		out := ensureLF(test.in)
+		assert.Equal(t, out, test.out)
+	}
 }

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -43,3 +43,39 @@ func TestMatchingAtStart(t *testing.T) {
 		[]Token{{Punctuation, "-"}, {NameEntity, "module"}, {Whitespace, " "}, {Operator, "->"}},
 		it.Tokens())
 }
+
+func TestEnsureLF(t *testing.T) {
+	l := Coalesce(MustNewLexer(&Config{}, Rules{
+		"root": {
+			{`(\w+)(\r?\n|\r)`, ByGroups(Keyword, Whitespace), nil},
+		},
+	}))
+	it, err := l.Tokenise(&TokeniseOptions{
+		State:    "root",
+		EnsureLF: true,
+	}, "hello\r\nworld\r")
+	assert.NoError(t, err)
+	assert.Equal(t, []Token{
+		{Keyword, "hello"},
+		{Whitespace, "\n"},
+		{Keyword, "world"},
+		{Whitespace, "\n"},
+	}, it.Tokens())
+
+	l = Coalesce(MustNewLexer(nil, Rules{
+		"root": {
+			{`(\w+)(\r?\n|\r)`, ByGroups(Keyword, Whitespace), nil},
+		},
+	}))
+	it, err = l.Tokenise(&TokeniseOptions{
+		State:    "root",
+		EnsureLF: false,
+	}, "hello\r\nworld\r")
+	assert.NoError(t, err)
+	assert.Equal(t, []Token{
+		{Keyword, "hello"},
+		{Whitespace, "\r\n"},
+		{Keyword, "world"},
+		{Whitespace, "\r"},
+	}, it.Tokens())
+}


### PR DESCRIPTION
ref #329
related https://github.com/gohugoio/hugo/issues/6596

I have been wondering if it is better to add this functionality to chroma in itself or chroma's client (such as Hugo) because it will be a breaking change somehow.

Walking around chroma's source code and playing with [your online demo](https://swapoff.org/chroma/playground/) (it always uses `\n` and works fine), I am inclined to implement this functionality on chroma rather than on its client because I assume that logics behind chroma expect `\n` as EOL .

So I added `EnsureLF` as `TokeniseOption` and the default values is true.

Any comments are welcome. 