### PR TITLE
Improve performance of lexers.Get function

### DIFF
--- a/lexers/internal/api.go
+++ b/lexers/internal/api.go
@@ -37,19 +37,20 @@ func Names(withAliases bool) []string {
 
 // Get a Lexer by name, alias or file extension.
 func Get(name string) chroma.Lexer {
-	candidates := chroma.PrioritisedLexers{}
 	if lexer := Registry.byName[name]; lexer != nil {
-		candidates = append(candidates, lexer)
+		return lexer
 	}
 	if lexer := Registry.byAlias[name]; lexer != nil {
-		candidates = append(candidates, lexer)
+		return lexer
 	}
 	if lexer := Registry.byName[strings.ToLower(name)]; lexer != nil {
-		candidates = append(candidates, lexer)
+		return lexer
 	}
 	if lexer := Registry.byAlias[strings.ToLower(name)]; lexer != nil {
-		candidates = append(candidates, lexer)
+		return lexer
 	}
+
+	candidates := chroma.PrioritisedLexers{}
 	// Try file extension.
 	if lexer := Match("filename." + name); lexer != nil {
 		candidates = append(candidates, lexer)

--- a/lexers/lexers_test.go
+++ b/lexers/lexers_test.go
@@ -38,6 +38,12 @@ func TestGet(t *testing.T) {
 	})
 }
 
+func BenchmarkGet(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		lexers.Get("go")
+	}
+}
+
 // Test source files are in the form <key>.<key> and validation data is in the form <key>.<key>.expected.
 func TestLexers(t *testing.T) {
 	files, err := ioutil.ReadDir("testdata")


### PR DESCRIPTION
The following benchmark test:

```go
func BenchmarkGet(b *testing.B) {
       for i := 0; i < b.N; i++ {
               lexers.Get("go")
       }
}
```

Shows the following results

```
go test -bench BenchmarkGet -run BenchmarkGet -v
```

```
goos: darwin
goarch: amd64
pkg: github.com/alecthomas/chroma/lexers
BenchmarkGet
BenchmarkGet-4   	    9336	    128457 ns/op
PASS
ok  	github.com/alecthomas/chroma/lexers	1.491s
```

Which is not so fast for a function that simply returns a lexer for a language. The reason is that we always try to find a lexer by a filename: https://github.com/alecthomas/chroma/blob/master/lexers/internal/api.go#L54. It has been done due to https://github.com/alecthomas/chroma/issues/94.

@alecthomas what do you think about returning a lexer if we found one by a provided name and only if we didn't find one we'd try to search by file extension? That would dramatically improve the performance:

```
goos: darwin
goarch: amd64
pkg: github.com/alecthomas/chroma/lexers
BenchmarkGet
BenchmarkGet-4   	40540636	        28.1 ns/op
PASS
ok  	github.com/alecthomas/chroma/lexers	1.329s
```

I've included the benchmark test just for demonstrating purposes