### PR TITLE
Fix invalid css when all styles is used

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -366,8 +366,12 @@ func (f *Formatter) WriteCSS(w io.Writer, style *chroma.Style) error {
 		if tt == chroma.Background {
 			continue
 		}
+		class := f.class(tt)
+		if class == "" {
+			continue
+		}
 		styles := css[tt]
-		if _, err := fmt.Fprintf(w, "/* %s */ .%schroma .%s { %s }\n", tt, f.prefix, f.class(tt), styles); err != nil {
+		if _, err := fmt.Fprintf(w, "/* %s */ .%schroma .%s { %s }\n", tt, f.prefix, class, styles); err != nil {
 			return err
 		}
 	}

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -222,3 +222,14 @@ func TestReconfigureOptions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, `<pre class="chroma"><span class="nb">echo</span> FOO</pre>`, buf.String())
 }
+
+func TestWriteCssWithAllClasses(t *testing.T) {
+	formatter := New()
+	formatter.allClasses = true
+
+	var buf bytes.Buffer
+	err := formatter.WriteCSS(&buf, styles.Fallback)
+
+	assert.NoError(t, err)
+	assert.NotContains(t, buf.String(), ".chroma . {", "Generated css doesn't contain invalid css")
+}


### PR DESCRIPTION
The `--all-styles` option currently produces invalid css for the `Text` token, because it doesn't have an associated class name.

The invalid css is `/* Text */ .chroma . {  }` and can be reproduced by running `chroma --html-styles --html-all-styles`.

More discussion about this issue at https://github.com/gohugoio/hugo/issues/7207