### PR TITLE
Bash: Parse single comment mark as comment

### DIFF
--- a/lexers/b/bash.go
+++ b/lexers/b/bash.go
@@ -36,7 +36,7 @@ var Bash = internal.Register(MustNewLexer(
 			{`\b(if|fi|else|while|do|done|for|then|return|function|case|select|continue|until|esac|elif)(\s*)\b`, ByGroups(Keyword, Text), nil},
 			{"\\b(alias|bg|bind|break|builtin|caller|cd|command|compgen|complete|declare|dirs|disown|echo|enable|eval|exec|exit|export|false|fc|fg|getopts|hash|help|history|jobs|kill|let|local|logout|popd|printf|pushd|pwd|read|readonly|set|shift|shopt|source|suspend|test|time|times|trap|true|type|typeset|ulimit|umask|unalias|unset|wait)(?=[\\s)`])", NameBuiltin, nil},
 			{`\A#!.+\n`, CommentPreproc, nil},
-			{`#.*\S`, CommentSingle, nil},
+			{`#.*(\S|$)`, CommentSingle, nil},
 			{`\\[\w\W]`, LiteralStringEscape, nil},
 			{`(\b\w+)(\s*)(\+?=)`, ByGroups(NameVariable, Text, Operator), nil},
 			{`[\[\]{}()=]`, Operator, nil},

--- a/lexers/testdata/bash.actual
+++ b/lexers/testdata/bash.actual
@@ -44,3 +44,6 @@ tiger_em () {
         shift
     done
 }
+
+# bare comment marker
+#

--- a/lexers/testdata/bash.expected
+++ b/lexers/testdata/bash.expected
@@ -130,5 +130,10 @@
   {"type":"Text","value":"\n    "},
   {"type":"Keyword","value":"done"},
   {"type":"Text","value":"\n"},
-  {"type":"Operator","value":"}"}
+  {"type":"Operator","value":"}"},
+  {"type":"Text","value":"\n\n"},
+  {"type":"CommentSingle","value":"# bare comment marker"},
+  {"type":"Text","value":"\n"},
+  {"type":"CommentSingle","value":"#"},
+  {"type":"Text","value":"\n"}
 ]


### PR DESCRIPTION
Fixes https://github.com/alecthomas/chroma/issues/318

| Before | After |
| -- | -- |
| <img width="174" alt="Screen Shot 2020-05-09 at 15 11 37" src="https://user-images.githubusercontent.com/329222/81474682-6d09b300-9207-11ea-9b00-656bf9a96f00.png"> | <img width="160" alt="Screen Shot 2020-05-09 at 15 11 15" src="https://user-images.githubusercontent.com/329222/81474687-6ed37680-9207-11ea-8fb2-74f5fa0a35ef.png"> |

