### PR TITLE
added curly braces to toml lexer

### DIFF
--- a/lexers/t/toml.go
+++ b/lexers/t/toml.go
@@ -22,7 +22,7 @@ var TOML = internal.Register(MustNewLexer(
 			{`[+-]?[0-9](_?\d)*`, LiteralNumberInteger, nil},
 			{`"(\\\\|\\"|[^"])*"`, StringDouble, nil},
 			{`'(\\\\|\\'|[^'])*'`, StringSingle, nil},
-			{`[.,=\[\]]`, Punctuation, nil},
+			{`[.,=\[\]{}]`, Punctuation, nil},
 			{`[^\W\d]\w*`, NameOther, nil},
 		},
 	},


### PR DESCRIPTION
I added curly braces to the TOML lexer. This should fix the error formatting of inline tables.
https://github.com/toml-lang/toml#user-content-inline-table

I have no go experience and did not test the build, so please excuse if this brakes everything ;-)