### PR TITLE
Fix golangci-lint download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - "1.13.x"
 script:
   - go test -v ./...
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s 1.26.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s v1.26.0
   - ./bin/golangci-lint run
   - git clean -fdx .
 after_success:


### PR DESCRIPTION
https://github.com/alecthomas/chroma/commit/2b9ea60d89edafe3fa89fd5443cb818f4b3be222 updated the version but removed the `v` prefix which I think is what makes the download fail.