### PR TITLE
Use EnsureNL for go lexer

### DIFF
--- a/lexers/g/go.go
+++ b/lexers/g/go.go
@@ -15,6 +15,7 @@ var Go = internal.Register(MustNewLexer(
 		Aliases:   []string{"go", "golang"},
 		Filenames: []string{"*.go"},
 		MimeTypes: []string{"text/x-gosrc"},
+		EnsureNL:  true,
 	},
 	Rules{
 		"root": {

--- a/lexers/testdata/go.actual
+++ b/lexers/testdata/go.actual
@@ -12,4 +12,4 @@ func hello(a int) {
     return func() int {
         return i
     }
-}
+} // One last thing

--- a/lexers/testdata/go.expected
+++ b/lexers/testdata/go.expected
@@ -58,5 +58,7 @@
   {"type":"Text","value":"\n    "},
   {"type":"Punctuation","value":"}"},
   {"type":"Text","value":"\n"},
-  {"type":"Punctuation","value":"}"}
+  {"type":"Punctuation","value":"}"},
+  {"type":"Text","value":" "},
+  {"type":"CommentSingle","value":"// One last thing\n"}
 ]


### PR DESCRIPTION
To allow proper detection of single line comments when there is no \n

Fixes #380