### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: false
+arch:
+  - ppc64le
+  - amd64
 language: go
 go:
   - "1.13.x"


### PR DESCRIPTION
Please review and merge the changes ,This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.