### PR TITLE
Update supported languages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,29 +36,30 @@ translators for Pygments lexers and styles.
 Prefix | Language
 :----: | --------
 A | ABAP, ABNF, ActionScript, ActionScript 3, Ada, Angular2, ANTLR, ApacheConf, APL, AppleScript, Arduino, Awk
-B | Ballerina, Base Makefile, Bash, Batchfile, BlitzBasic, BNF, Brainfuck
-C | C, C#, C++, Cap'n Proto, Cassandra CQL, Ceylon, CFEngine3, cfstatement, ChaiScript, Cheetah, Clojure, CMake, COBOL, CoffeeScript, Common Lisp, Coq, Crystal, CSS, Cython
+B | Ballerina, Base Makefile, Bash, Batchfile, BibTeX, BlitzBasic, BNF, Brainfuck
+C | C, C#, C++, Caddyfile, Caddyfile Directives, Cap'n Proto, Cassandra CQL, Ceylon, CFEngine3, cfstatement, ChaiScript, Cheetah, Clojure, CMake, COBOL, CoffeeScript, Common Lisp, Coq, Crystal, CSS, Cython
 D | D, Dart, Diff, Django/Jinja, Docker, DTD
 E | EBNF, Elixir, Elm, EmacsLisp, Erlang
 F | Factor, Fish, Forth, Fortran, FSharp
-G | GAS, GDScript, Genshi, Genshi HTML, Genshi Text, GLSL, Gnuplot, Go, Go HTML Template, Go Text Template, GraphQL, Groovy
-H | Handlebars, Haskell, Haxe, HCL, Hexdump, HTML, HTTP, Hy
-I | Idris, INI, Io
+G | GAS, GDScript, Genshi, Genshi HTML, Genshi Text, Gherkin, GLSL, Gnuplot, Go, Go HTML Template, Go Text Template, GraphQL, Groovy
+H | Handlebars, Haskell, Haxe, HCL, Hexdump, HLB, HTML, HTTP, Hy
+I | Idris, Igor, INI, Io
 J | J, Java, JavaScript, JSON, Julia, Jungle
 K | Kotlin
 L | Lighttpd configuration file, LLVM, Lua
 M | Mako, markdown, Mason, Mathematica, Matlab, MiniZinc, MLIR, Modula-2, MonkeyC, MorrowindScript, Myghty, MySQL
 N | NASM, Newspeak, Nginx configuration file, Nim, Nix
 O | Objective-C, OCaml, Octave, OpenSCAD, Org Mode
-P | PacmanConf, Perl, PHP, Pig, PkgConfig, PL/pgSQL, plaintext, PostgreSQL SQL dialect, PostScript, POVRay, PowerShell, Prolog, Protocol Buffer, Puppet, Python, Python 3
+P | PacmanConf, Perl, PHP, PHTML, Pig, PkgConfig, PL/pgSQL, plaintext, Pony, PostgreSQL SQL dialect, PostScript, POVRay, PowerShell, Prolog, PromQL, Protocol Buffer, Puppet, Python, Python 3
 Q | QBasic
-R | R, Racket, Ragel, react, reg, reStructuredText, Rexx, Ruby, Rust
-S | Sass, Scala, Scheme, Scilab, SCSS, Smalltalk, Smarty, SML, Snobol, Solidity, SPARQL, SQL, SquidConf, Swift, SYSTEMD, systemverilog
+R | R, Racket, Ragel, react, ReasonML, reg, reStructuredText, Rexx, Ruby, Rust
+S | SAS, Sass, Scala, Scheme, Scilab, SCSS, Smalltalk, Smarty, Snobol, Solidity, SPARQL, SQL, SquidConf, Standard ML, Stylus, Swift, SYSTEMD, systemverilog
 T | TableGen, TASM, Tcl, Tcsh, Termcap, Terminfo, Terraform, TeX, Thrift, TOML, TradingView, Transact-SQL, Turing, Turtle, Twig, TypeScript, TypoScript, TypoScriptCssData, TypoScriptHtmlData
 V | VB.net, verilog, VHDL, VimL, vue
 W | WDTE
 X | XML, Xorg
-Y | YAML
+Y | YAML, YANG
+Z | Zig
 
 
 _I will attempt to keep this section up to date, but an authoritative list can be

--- a/table.py
+++ b/table.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
+import re
 from collections import defaultdict
 from subprocess import check_output
+
+README_FILE = "README.md"
+
 
 lines = check_output(["go", "run", "./cmd/chroma/main.go", "--list"]).decode("utf-8").splitlines()
 lines = [line.strip() for line in lines if line.startswith("  ") and not line.startswith("   ")]
@@ -11,5 +15,18 @@ table = defaultdict(list)
 for line in lines:
     table[line[0].upper()].append(line)
 
+rows = []
 for key, value in table.items():
-    print("{} | {}".format(key, ", ".join(value)))
+    rows.append("{} | {}".format(key, ", ".join(value)))
+tbody = "\n".join(rows)
+
+with open(README_FILE, "r") as f:
+    content = f.read()
+
+with open(README_FILE, "w") as f:
+    marker = re.compile(r"(?P<start>:----: \\| --------\n).*?(?P<end>\n\n)", re.DOTALL)
+    replacement = r"\g<start>%s\g<end>" % tbody
+    updated_content = marker.sub(replacement, content)
+    f.write(updated_content)
+
+print(tbody)

--- a/table.py
+++ b/table.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from subprocess import check_output
 
-lines = check_output(["go", "run", "./cmd/chroma/main.go", "--list"]).decode('utf-8').splitlines()
+lines = check_output(["go", "run", "./cmd/chroma/main.go", "--list"]).decode("utf-8").splitlines()
 lines = [line.strip() for line in lines if line.startswith("  ") and not line.startswith("   ")]
 lines = sorted(lines, key=lambda l: l.lower())
 
@@ -12,4 +12,4 @@ for line in lines:
     table[line[0].upper()].append(line)
 
 for key, value in table.items():
-    print("{} | {}".format(key, ', '.join(value)))
+    print("{} | {}".format(key, ", ".join(value)))


### PR DESCRIPTION
This PR update the `table.py` script allowing to write the content directly into `README.md` to avoid manual actions and maybe could be useful to automate the release steps.
The table of supported languages was update using the script.

I tried to keep the script as simple and flat as possible, using only Python 3.x built-in functions. I though about the idea to implemented with a `--write-in-place` option but I don't know if it worth it.

In any case, feel free to request any changes you think could be appropriate, provide any feedback, or even just drop this PR because I know that adding more code implies more maintenance. Thanks for your time!

 
