### PR TITLE
Move lexers to correct folders

### DIFF
--- a/lexers/h/hlb.go
+++ b/lexers/h/hlb.go
@@ -1,4 +1,4 @@
-package lexers
+package h
 
 import (
 	. "github.com/alecthomas/chroma" // nolint

--- a/lexers/q/qml.go
+++ b/lexers/q/qml.go
@@ -1,4 +1,4 @@
-package lexers
+package q
 
 import (
 	. "github.com/alecthomas/chroma" // nolint


### PR DESCRIPTION
This PR moves `hlb` and `qml` lexers to correct subfolders.