### PR TITLE
LiteralNumberHex: underscore support

### DIFF
--- a/lexers/circular/php.go
+++ b/lexers/circular/php.go
@@ -51,7 +51,7 @@ func phpCommonRules() Rules {
 			{`(\d+\.\d*|\d*\.\d+)(e[+-]?[0-9]+)?`, LiteralNumberFloat, nil},
 			{`\d+e[+-]?[0-9]+`, LiteralNumberFloat, nil},
 			{`0[0-7]+`, LiteralNumberOct, nil},
-			{`0x[a-f0-9]+`, LiteralNumberHex, nil},
+			{`0x[a-f0-9_]+`, LiteralNumberHex, nil},
 			{`[\d_]+`, LiteralNumberInteger, nil},
 			{`0b[01]+`, LiteralNumberBin, nil},
 			{`'([^'\\]*(?:\\.[^'\\]*)*)'`, LiteralStringSingle, nil},

--- a/lexers/g/go.go
+++ b/lexers/g/go.go
@@ -49,7 +49,7 @@ func goRules() Rules {
 			{`\d+(\.\d+[eE][+\-]?\d+|\.\d*|[eE][+\-]?\d+)`, LiteralNumberFloat, nil},
 			{`\.\d+([eE][+\-]?\d+)?`, LiteralNumberFloat, nil},
 			{`0[0-7]+`, LiteralNumberOct, nil},
-			{`0[xX][0-9a-fA-F]+`, LiteralNumberHex, nil},
+			{`0[xX][0-9a-fA-F_]+`, LiteralNumberHex, nil},
 			{`(0|[1-9][0-9_]*)`, LiteralNumberInteger, nil},
 			{`'(\\['"\\abfnrtv]|\\x[0-9a-fA-F]{2}|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\U[0-9a-fA-F]{8}|[^\\])'`, LiteralStringChar, nil},
 			{"(`)([^`]*)(`)", ByGroups(LiteralString, Using(TypeRemappingLexer(GoTextTemplate, TypeMapping{{Other, LiteralString, nil}})), LiteralString), nil},

--- a/lexers/p/python.go
+++ b/lexers/p/python.go
@@ -69,7 +69,7 @@ func pythonRules() Rules {
 			{`\d+[eE][+-]?[0-9]+j?`, LiteralNumberFloat, nil},
 			{`0[0-7]+j?`, LiteralNumberOct, nil},
 			{`0[bB][01]+`, LiteralNumberBin, nil},
-			{`0[xX][a-fA-F0-9]+`, LiteralNumberHex, nil},
+			{`0[xX][a-fA-F0-9_]+`, LiteralNumberHex, nil},
 			{`\d+L`, LiteralNumberIntegerLong, nil},
 			{`[\d_]+j?`, LiteralNumberInteger, nil},
 		},


### PR DESCRIPTION
Most languages allow for underscore in number literals. Fix support for a few
languages. References:

- https://docs.python.org/reference/lexical_analysis.html#integer-literals
- https://golang.org/ref/spec#Integer_literals
- https://php.net/language.types.integer