### PR TITLE
fix: synthesisable entries are ignored when cloned

### DIFF
--- a/style.go
+++ b/style.go
@@ -265,11 +265,11 @@ func (s *Style) Get(ttype TokenType) StyleEntry {
 
 func (s *Style) get(ttype TokenType) StyleEntry {
 	out := s.entries[ttype]
-	if out.IsZero() && s.synthesisable(ttype) {
-		out = s.synthesise(ttype)
-	}
 	if out.IsZero() && s.parent != nil {
 		return s.parent.get(ttype)
+	}
+	if out.IsZero() && s.synthesisable(ttype) {
+		out = s.synthesise(ttype)
 	}
 	return out
 }

--- a/style_test.go
+++ b/style_test.go
@@ -48,3 +48,17 @@ func TestSynthesisedStyleEntries(t *testing.T) {
 	assert.Equal(t, "#7f7f7f bg:#ffffff", style.Get(LineNumbers).String())
 	assert.Equal(t, "#7f7f7f bg:#ffffff", style.Get(LineNumbersTable).String())
 }
+
+func TestSynthesisedStyleClone(t *testing.T) {
+	style, err := NewStyle("test", StyleEntries{
+		Background:    "bg:#ffffff",
+		LineHighlight: "bg:#ffffff",
+		LineNumbers:   "bg:#fffff1",
+	})
+	style, err = style.Builder().Build()
+	assert.NoError(t, err)
+	assert.True(t, style.Has(LineHighlight))
+	assert.True(t, style.Has(LineNumbers))
+	assert.Equal(t, "bg:#ffffff", style.Get(LineHighlight).String())
+	assert.Equal(t, "bg:#fffff1", style.Get(LineNumbers).String())
+}

--- a/style_test.go
+++ b/style_test.go
@@ -55,6 +55,7 @@ func TestSynthesisedStyleClone(t *testing.T) {
 		LineHighlight: "bg:#ffffff",
 		LineNumbers:   "bg:#fffff1",
 	})
+	assert.NoError(t, err)
 	style, err = style.Builder().Build()
 	assert.NoError(t, err)
 	assert.True(t, style.Has(LineHighlight))


### PR DESCRIPTION
For example, if `chroma` is invoked on the command line, `LineNumbers`, `LineHighlight` et al are ignored.