### PR TITLE
style: better solarized light

### DIFF
--- a/styles/solarized-light.go
+++ b/styles/solarized-light.go
@@ -5,20 +5,53 @@ import (
 )
 
 // SolarizedLight style.
-var SolarizedLight = Register(chroma.MustNewStyle("solarized-light", chroma.StyleEntries{
-	chroma.Text:             "bg: #eee8d5 #586e75",
-	chroma.Keyword:          "#859900",
-	chroma.KeywordConstant:  "bold",
-	chroma.KeywordNamespace: "#dc322f bold",
-	chroma.KeywordType:      "bold",
-	chroma.Name:             "#268bd2",
-	chroma.NameBuiltin:      "#cb4b16",
-	chroma.NameClass:        "#cb4b16",
-	chroma.NameTag:          "bold",
-	chroma.Literal:          "#2aa198",
-	chroma.LiteralNumber:    "bold",
-	chroma.OperatorWord:     "#859900",
-	chroma.Comment:          "#93a1a1 italic",
-	chroma.Generic:          "#d33682",
-	chroma.Background:       " bg:#eee8d5",
-}))
+var SolarizedLight = Register(chroma.MustNewStyle("solarized-light", func() chroma.StyleEntries {
+	var (
+		base00  = "#657b83"
+		base0   = "#839496"
+		base1   = "#93a1a1"
+		base2   = "#eee8d5"
+		base3   = "#fdf6e3"
+		yellow  = "#b58900"
+		orange  = "#cb4b16"
+		red     = "#dc322f"
+		magenta = "#d33682"
+		blue    = "#268bd2"
+		cyan    = "#2aa198"
+		green   = "#859900"
+	)
+
+	return chroma.StyleEntries{
+		chroma.Text:                base00,
+		chroma.Keyword:             green,
+		chroma.KeywordNamespace:    orange,
+		chroma.KeywordDeclaration:  blue,
+		chroma.KeywordType:         yellow,
+		chroma.Name:                base00,
+		chroma.NameBuiltin:         green,
+		chroma.NameTag:             "bold " + blue,
+		chroma.Literal:             cyan,
+		chroma.LiteralStringEscape: orange,
+		chroma.LiteralNumber:       magenta,
+		chroma.LiteralStringRegex:  orange,
+		chroma.OperatorWord:        green,
+		chroma.Comment:             "italic " + base1,
+		chroma.CommentPreproc:      "noitalic " + orange,
+		chroma.CommentPreprocFile:  cyan,
+		chroma.CommentSpecial:      "noitalic " + cyan,
+		chroma.Generic:             base00,
+		chroma.GenericDeleted:      red,
+		chroma.GenericEmph:         "italic",
+		chroma.GenericError:        red,
+		chroma.GenericHeading:      "bold",
+		chroma.GenericSubheading:   "bold",
+		chroma.GenericInserted:     green,
+		chroma.GenericPrompt:       "bold " + blue,
+		chroma.GenericStrong:       "bold",
+		chroma.GenericUnderline:    "underline",
+		chroma.Background:          "bg:" + base3,
+		chroma.LineNumbers:         base0 + " bg:" + base2,
+		chroma.LineHighlight:       "bg:" + base2,
+		chroma.Error:               "bg:" + red,
+	}
+}()))

--- a/styles/vulcan.go
+++ b/styles/vulcan.go
@@ -4,92 +4,94 @@ import (
 	"github.com/alecthomas/chroma"
 )
 
-var (
-	// inspired by Doom Emacs's One Doom Theme
-	black  = "#282C34"
-	grey   = "#3E4460"
-	grey2  = "#43454f"
-	white  = "#C9C9C9"
-	red    = "#CF5967"
-	yellow = "#ECBE7B"
-	green  = "#82CC6A"
-	cyan   = "#56B6C2"
-	blue   = "#7FBAF5"
-	blue2  = "#57C7FF"
-	purple = "#BC74C4"
-)
+var Vulcan = Register(chroma.MustNewStyle("vulcan", func() chroma.StyleEntries {
+	var (
+		// inspired by Doom Emacs's One Doom Theme
+		black  = "#282C34"
+		grey   = "#3E4460"
+		grey2  = "#43454f"
+		white  = "#C9C9C9"
+		red    = "#CF5967"
+		yellow = "#ECBE7B"
+		green  = "#82CC6A"
+		cyan   = "#56B6C2"
+		blue   = "#7FBAF5"
+		blue2  = "#57C7FF"
+		purple = "#BC74C4"
+	)
 
-var Vulcan = Register(chroma.MustNewStyle("vulcan", chroma.StyleEntries{
-	chroma.Comment:                  grey,
-	chroma.CommentHashbang:          grey + " italic",
-	chroma.CommentMultiline:         grey,
-	chroma.CommentPreproc:           blue,
-	chroma.CommentSingle:            grey,
-	chroma.CommentSpecial:           purple + " italic",
-	chroma.Generic:                  white,
-	chroma.GenericDeleted:           red,
-	chroma.GenericEmph:              white + " underline",
-	chroma.GenericError:             red + " bold",
-	chroma.GenericHeading:           yellow + " bold",
-	chroma.GenericInserted:          yellow,
-	chroma.GenericOutput:            grey2,
-	chroma.GenericPrompt:            white,
-	chroma.GenericStrong:            red + " bold",
-	chroma.GenericSubheading:        red + " italic",
-	chroma.GenericTraceback:         white,
-	chroma.GenericUnderline:         "underline",
-	chroma.Error:                    red,
-	chroma.Keyword:                  blue,
-	chroma.KeywordConstant:          red + " bg:" + grey2,
-	chroma.KeywordDeclaration:       blue,
-	chroma.KeywordNamespace:         purple,
-	chroma.KeywordPseudo:            purple,
-	chroma.KeywordReserved:          blue,
-	chroma.KeywordType:              blue2 + " bold",
-	chroma.Literal:                  white,
-	chroma.LiteralDate:              blue2,
-	chroma.Name:                     white,
-	chroma.NameAttribute:            purple,
-	chroma.NameBuiltin:              blue,
-	chroma.NameBuiltinPseudo:        blue,
-	chroma.NameClass:                yellow,
-	chroma.NameConstant:             yellow,
-	chroma.NameDecorator:            yellow,
-	chroma.NameEntity:               white,
-	chroma.NameException:            red,
-	chroma.NameFunction:             blue2,
-	chroma.NameLabel:                red,
-	chroma.NameNamespace:            white,
-	chroma.NameOther:                white,
-	chroma.NameTag:                  purple,
-	chroma.NameVariable:             purple + " italic",
-	chroma.NameVariableClass:        blue2 + " bold",
-	chroma.NameVariableGlobal:       yellow,
-	chroma.NameVariableInstance:     blue2,
-	chroma.LiteralNumber:            cyan,
-	chroma.LiteralNumberBin:         blue2,
-	chroma.LiteralNumberFloat:       cyan,
-	chroma.LiteralNumberHex:         blue2,
-	chroma.LiteralNumberInteger:     cyan,
-	chroma.LiteralNumberIntegerLong: cyan,
-	chroma.LiteralNumberOct:         blue2,
-	chroma.Operator:                 purple,
-	chroma.OperatorWord:             purple,
-	chroma.Other:                    white,
-	chroma.Punctuation:              cyan,
-	chroma.LiteralString:            green,
-	chroma.LiteralStringBacktick:    blue2,
-	chroma.LiteralStringChar:        blue2,
-	chroma.LiteralStringDoc:         green,
-	chroma.LiteralStringDouble:      green,
-	chroma.LiteralStringEscape:      cyan,
-	chroma.LiteralStringHeredoc:     cyan,
-	chroma.LiteralStringInterpol:    green,
-	chroma.LiteralStringOther:       green,
-	chroma.LiteralStringRegex:       blue2,
-	chroma.LiteralStringSingle:      green,
-	chroma.LiteralStringSymbol:      green,
-	chroma.Text:                     white,
-	chroma.TextWhitespace:           white,
-	chroma.Background:               " bg: " + black,
-}))
+	return chroma.StyleEntries{
+		chroma.Comment:                  grey,
+		chroma.CommentHashbang:          grey + " italic",
+		chroma.CommentMultiline:         grey,
+		chroma.CommentPreproc:           blue,
+		chroma.CommentSingle:            grey,
+		chroma.CommentSpecial:           purple + " italic",
+		chroma.Generic:                  white,
+		chroma.GenericDeleted:           red,
+		chroma.GenericEmph:              white + " underline",
+		chroma.GenericError:             red + " bold",
+		chroma.GenericHeading:           yellow + " bold",
+		chroma.GenericInserted:          yellow,
+		chroma.GenericOutput:            grey2,
+		chroma.GenericPrompt:            white,
+		chroma.GenericStrong:            red + " bold",
+		chroma.GenericSubheading:        red + " italic",
+		chroma.GenericTraceback:         white,
+		chroma.GenericUnderline:         "underline",
+		chroma.Error:                    red,
+		chroma.Keyword:                  blue,
+		chroma.KeywordConstant:          red + " bg:" + grey2,
+		chroma.KeywordDeclaration:       blue,
+		chroma.KeywordNamespace:         purple,
+		chroma.KeywordPseudo:            purple,
+		chroma.KeywordReserved:          blue,
+		chroma.KeywordType:              blue2 + " bold",
+		chroma.Literal:                  white,
+		chroma.LiteralDate:              blue2,
+		chroma.Name:                     white,
+		chroma.NameAttribute:            purple,
+		chroma.NameBuiltin:              blue,
+		chroma.NameBuiltinPseudo:        blue,
+		chroma.NameClass:                yellow,
+		chroma.NameConstant:             yellow,
+		chroma.NameDecorator:            yellow,
+		chroma.NameEntity:               white,
+		chroma.NameException:            red,
+		chroma.NameFunction:             blue2,
+		chroma.NameLabel:                red,
+		chroma.NameNamespace:            white,
+		chroma.NameOther:                white,
+		chroma.NameTag:                  purple,
+		chroma.NameVariable:             purple + " italic",
+		chroma.NameVariableClass:        blue2 + " bold",
+		chroma.NameVariableGlobal:       yellow,
+		chroma.NameVariableInstance:     blue2,
+		chroma.LiteralNumber:            cyan,
+		chroma.LiteralNumberBin:         blue2,
+		chroma.LiteralNumberFloat:       cyan,
+		chroma.LiteralNumberHex:         blue2,
+		chroma.LiteralNumberInteger:     cyan,
+		chroma.LiteralNumberIntegerLong: cyan,
+		chroma.LiteralNumberOct:         blue2,
+		chroma.Operator:                 purple,
+		chroma.OperatorWord:             purple,
+		chroma.Other:                    white,
+		chroma.Punctuation:              cyan,
+		chroma.LiteralString:            green,
+		chroma.LiteralStringBacktick:    blue2,
+		chroma.LiteralStringChar:        blue2,
+		chroma.LiteralStringDoc:         green,
+		chroma.LiteralStringDouble:      green,
+		chroma.LiteralStringEscape:      cyan,
+		chroma.LiteralStringHeredoc:     cyan,
+		chroma.LiteralStringInterpol:    green,
+		chroma.LiteralStringOther:       green,
+		chroma.LiteralStringRegex:       blue2,
+		chroma.LiteralStringSingle:      green,
+		chroma.LiteralStringSymbol:      green,
+		chroma.Text:                     white,
+		chroma.TextWhitespace:           white,
+		chroma.Background:               " bg: " + black,
+	}
+}()))


### PR DESCRIPTION
I have noticed that the current implementation of solarized light is a bit far from the original. This PR makes this style looks closer to the original and more complete.

It is impossible to perfectly match with the original since the original colouring is language-dependant.

Original (Vim):
![original](https://raw.githubusercontent.com/altercation/solarized/master/img/screen-javascript-light.png)

Chroma:
![chroma](https://user-images.githubusercontent.com/54489058/114294933-d1fd0700-9a6f-11eb-89b5-c3df7037a43d.png)

After:
![after](https://user-images.githubusercontent.com/54489058/114294957-01137880-9a70-11eb-90bb-caaba17f5ae2.png)