### PR TITLE
File name matches and mime matches should be moved to phtml from php lexer

### DIFF
--- a/lexers/circular/php.go
+++ b/lexers/circular/php.go
@@ -10,8 +10,8 @@ var PHP = internal.Register(MustNewLazyLexer(
 	&Config{
 		Name:            "PHP",
 		Aliases:         []string{"php", "php3", "php4", "php5"},
-		Filenames:       []string{},
-		MimeTypes:       []string{},
+		Filenames:       []string{"*.php", "*.php[345]", "*.inc"},
+		MimeTypes:       []string{"text/x-php"},
 		DotAll:          true,
 		CaseInsensitive: true,
 		EnsureNL:        true,

--- a/lexers/circular/php.go
+++ b/lexers/circular/php.go
@@ -10,8 +10,8 @@ var PHP = internal.Register(MustNewLazyLexer(
 	&Config{
 		Name:            "PHP",
 		Aliases:         []string{"php", "php3", "php4", "php5"},
-		Filenames:       []string{"*.php", "*.php[345]", "*.inc"},
-		MimeTypes:       []string{"text/x-php"},
+		Filenames:       []string{},
+		MimeTypes:       []string{},
 		DotAll:          true,
 		CaseInsensitive: true,
 		EnsureNL:        true,

--- a/lexers/circular/phtml.go
+++ b/lexers/circular/phtml.go
@@ -18,6 +18,7 @@ var PHTML = internal.Register(DelegatingLexer(h.HTML, MustNewLazyLexer(
 		DotAll:          true,
 		CaseInsensitive: true,
 		EnsureNL:        true,
+		Priority:        2,
 	},
 	phtmlRules,
 ).SetAnalyser(func(text string) float32 {

--- a/lexers/circular/phtml.go
+++ b/lexers/circular/phtml.go
@@ -13,8 +13,8 @@ var PHTML = internal.Register(DelegatingLexer(h.HTML, MustNewLazyLexer(
 	&Config{
 		Name:            "PHTML",
 		Aliases:         []string{"phtml"},
-		Filenames:       []string{"*.phtml"},
-		MimeTypes:       []string{"application/x-php", "application/x-httpd-php", "application/x-httpd-php3", "application/x-httpd-php4", "application/x-httpd-php5"},
+		Filenames:       []string{"*.phtml", "*.php", "*.php[345]", "*.inc"},
+		MimeTypes:       []string{"application/x-php", "application/x-httpd-php", "application/x-httpd-php3", "application/x-httpd-php4", "application/x-httpd-php5", "text/x-php"},
 		DotAll:          true,
 		CaseInsensitive: true,
 		EnsureNL:        true,


### PR DESCRIPTION
I had an issue with gitea where syntax highlighting of PHP code mixed with HTML was not working, in reviewing we identified that the tag changes were made and the PHTML lexer was created in order to allow syntax highlighting of PHP code without the starting tag in markdown snippets (https://github.com/alecthomas/chroma/issues/210). These changes, however, cause issues when the PHP lexer is identified to parse files with the extension of `.php`.

For an example, with the file name/mime matches being on the PHP lexer, if we were to identify this file with either the mime type or file name, the PHP lexer will be used and the file will be highlighted incorrectly.

https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentytwentyone/template-parts/content/content-page.php

I recommend that we move the file name matches and mime type from the PHP lexer to the PHTML lexer so that when we are identifying based on mime type or file name, the proper lexer is used.

My understanding is that the markdown identification of syntax highlighting is not based on file name or mime type, so a change like this should not affect the main reason the change was made. I have tested with `cmd/chroma/chroma -s monokailight --html --html-lines --html-lines-table --html-inline-styles content-page.php` and changes seem to work.