### PR TITLE
toml: allow `-` in keys

### DIFF
--- a/lexers/t/toml.go
+++ b/lexers/t/toml.go
@@ -27,7 +27,7 @@ func tomlRules() Rules {
 			{`"(\\\\|\\"|[^"])*"`, StringDouble, nil},
 			{`'(\\\\|\\'|[^'])*'`, StringSingle, nil},
 			{`[.,=\[\]{}]`, Punctuation, nil},
-			{`[^\W\d]\w*`, NameOther, nil},
+			{`[A-Za-z0-9_-]+`, NameOther, nil},
 		},
 	}
 }


### PR DESCRIPTION
The current TOML lexer doesn't consider `-` as valid part of a TOML key, but this is [legal per the v1.0.0 TOML spec](https://toml.io/en/v1.0.0#keys). In the wild, this is the style used in `pyproject.toml` files.  

This patch makes the lexer use the same character ranges as the ones specified by the spec. 