### PR TITLE
sort lexers with lower case

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -2,6 +2,7 @@ package chroma
 
 import (
 	"fmt"
+	"strings"
 )
 
 var (
@@ -98,9 +99,11 @@ type Lexer interface {
 // Lexers is a slice of lexers sortable by name.
 type Lexers []Lexer
 
-func (l Lexers) Len() int           { return len(l) }
-func (l Lexers) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
-func (l Lexers) Less(i, j int) bool { return l[i].Config().Name < l[j].Config().Name }
+func (l Lexers) Len() int      { return len(l) }
+func (l Lexers) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+func (l Lexers) Less(i, j int) bool {
+	return strings.ToLower(l[i].Config().Name) < strings.ToLower(l[j].Config().Name)
+}
 
 // PrioritisedLexers is a slice of lexers sortable by priority.
 type PrioritisedLexers []Lexer


### PR DESCRIPTION
In the current state, lexers that have names that begin with lower case characters are all sorted at the bottom.

For example, the end of the `chroma --list` cli command is this

```shell
  YANG
    aliases: yang
    filenames: *.yang
    mimetypes: application/yang
  Zig
    aliases: zig
    filenames: *.zig
    mimetypes: text/zig
  cfstatement
    aliases: cfs
  markdown
    aliases: md mkd
    filenames: *.md *.mkd *.markdown
    mimetypes: text/x-markdown
  mcfunction
    aliases: mcfunction
    filenames: *.mcfunction
  plaintext
    aliases: text plain no-highlight
    filenames: *.txt
    mimetypes: text/plain
  reStructuredText
    aliases: rst rest restructuredtext
    filenames: *.rst *.rest
    mimetypes: text/x-rst text/prs.fallenstein.rst
  react
    aliases: jsx react
    filenames: *.jsx *.react
    mimetypes: text/jsx text/typescript-jsx
  reg
    aliases: registry
    filenames: *.reg
    mimetypes: text/x-windows-registry
  systemverilog
    aliases: systemverilog sv
    filenames: *.sv *.svh
    mimetypes: text/x-systemverilog
  verilog
    aliases: verilog v
    filenames: *.v
    mimetypes: text/x-verilog
  vue
    aliases: vue vuejs
    filenames: *.vue
    mimetypes: text/x-vue application/x-vue
```