### PR TITLE
Pass `*LexerState` as context to emitters

### DIFF
--- a/lexers/h/http.go
+++ b/lexers/h/http.go
@@ -37,14 +37,14 @@ func httpRules() Rules {
 	}
 }
 
-func httpContentBlock(groups []string, lexer Lexer) Iterator {
+func httpContentBlock(groups []string, state *LexerState) Iterator {
 	tokens := []Token{
 		{Generic, groups[0]},
 	}
 	return Literator(tokens...)
 }
 
-func httpHeaderBlock(groups []string, lexer Lexer) Iterator {
+func httpHeaderBlock(groups []string, state *LexerState) Iterator {
 	tokens := []Token{
 		{Name, groups[1]},
 		{Text, groups[2]},
@@ -56,7 +56,7 @@ func httpHeaderBlock(groups []string, lexer Lexer) Iterator {
 	return Literator(tokens...)
 }
 
-func httpContinuousHeaderBlock(groups []string, lexer Lexer) Iterator {
+func httpContinuousHeaderBlock(groups []string, state *LexerState) Iterator {
 	tokens := []Token{
 		{Text, groups[1]},
 		{Literal, groups[2]},

--- a/lexers/r/raku.go
+++ b/lexers/r/raku.go
@@ -1319,7 +1319,7 @@ func makeRuleAndPushMaybe(config RuleMakingConfig) *CompiledRule {
 
 // Emitter for colon pairs, changes token state based on key and brackets
 func colonPair(tokenClass TokenType) Emitter {
-	return EmitterFunc(func(groups []string, lexer Lexer) Iterator {
+	return EmitterFunc(func(groups []string, state *LexerState) Iterator {
 		iterators := []Iterator{}
 		tokens := []Token{
 			{Punctuation, groups[1]},
@@ -1343,7 +1343,7 @@ func colonPair(tokenClass TokenType) Emitter {
 
 			// Use token state to Tokenise key
 			if keyTokenState != "" {
-				iterator, err := lexer.Tokenise(
+				iterator, err := state.Lexer.Tokenise(
 					&TokeniseOptions{
 						State:  keyTokenState,
 						Nested: true,
@@ -1374,7 +1374,7 @@ func colonPair(tokenClass TokenType) Emitter {
 
 		// Use token state to Tokenise value
 		if valueTokenState != "" {
-			iterator, err := lexer.Tokenise(
+			iterator, err := state.Lexer.Tokenise(
 				&TokeniseOptions{
 					State:  valueTokenState,
 					Nested: true,
@@ -1394,7 +1394,7 @@ func colonPair(tokenClass TokenType) Emitter {
 }
 
 // Emitter for quoting constructs, changes token state based on quote name and adverbs
-func quote(groups []string, lexer Lexer) Iterator {
+func quote(groups []string, state *LexerState) Iterator {
 	iterators := []Iterator{}
 	tokens := []Token{
 		{Keyword, groups[1]},
@@ -1443,7 +1443,7 @@ func quote(groups []string, lexer Lexer) Iterator {
 		tokenState = "Q"
 	}
 
-	iterator, err := lexer.Tokenise(
+	iterator, err := state.Lexer.Tokenise(
 		&TokeniseOptions{
 			State:  tokenState,
 			Nested: true,
@@ -1462,9 +1462,9 @@ func quote(groups []string, lexer Lexer) Iterator {
 }
 
 // Emitter for pod config, tokenises the properties with "colon-pair-attribute" state
-func podConfig(groups []string, lexer Lexer) Iterator {
+func podConfig(groups []string, state *LexerState) Iterator {
 	// Tokenise pod config
-	iterator, err := lexer.Tokenise(
+	iterator, err := state.Lexer.Tokenise(
 		&TokeniseOptions{
 			State:  "colon-pair-attribute",
 			Nested: true,
@@ -1478,7 +1478,7 @@ func podConfig(groups []string, lexer Lexer) Iterator {
 }
 
 // Emitter for pod code, tokenises the code based on the lang specified
-func podCode(groups []string, lexer Lexer) Iterator {
+func podCode(groups []string, state *LexerState) Iterator {
 	iterators := []Iterator{}
 	tokens := []Token{
 		{Keyword, groups[1]},
@@ -1496,7 +1496,7 @@ func podCode(groups []string, lexer Lexer) Iterator {
 	iterators = append(iterators, Literator(tokens[:4]...))
 
 	// Tokenise pod config
-	iterators = append(iterators, podConfig([]string{groups[5]}, lexer))
+	iterators = append(iterators, podConfig([]string{groups[5]}, state))
 
 	langMatch := regexp.MustCompile(`:lang\W+(\w+)`).FindStringSubmatch(groups[5])
 	var lang string

--- a/lexers/r/rst.go
+++ b/lexers/r/rst.go
@@ -63,7 +63,7 @@ func restructuredtextRules() Rules {
 	}
 }
 
-func rstCodeBlock(groups []string, lexer Lexer) Iterator {
+func rstCodeBlock(groups []string, state *LexerState) Iterator {
 	iterators := []Iterator{}
 	tokens := []Token{
 		{Punctuation, groups[1]},
@@ -75,7 +75,7 @@ func rstCodeBlock(groups []string, lexer Lexer) Iterator {
 		{Text, groups[7]},
 	}
 	code := strings.Join(groups[8:], "")
-	lexer = internal.Get(groups[6])
+	lexer := internal.Get(groups[6])
 	if lexer == nil {
 		tokens = append(tokens, Token{String, code})
 		iterators = append(iterators, Literator(tokens...))

--- a/types.go
+++ b/types.go
@@ -342,6 +342,6 @@ func (t TokenType) InSubCategory(other TokenType) bool {
 	return t/100 == other/100
 }
 
-func (t TokenType) Emit(groups []string, lexer Lexer) Iterator {
+func (t TokenType) Emit(groups []string, _ *LexerState) Iterator {
 	return Literator(Token{Type: t, Value: groups[0]})
 }


### PR DESCRIPTION
Useful for accessing named capture groups and context set by
`mutators` and other fields and methods LexerState provides.

I don't know if you'll accept this pull request, or if I did it the right way, cause I
don't know enough Go. But you mentioned it [here](https://github.com/alecthomas/chroma/issues/306#issuecomment-559304648).
I tried to make an `Interface` without changing the current emitters and tried
different things, the only thing that worked was changing the type of `Rule`
to an `interface{}` and type assert it while emitting the rule. For example:

``` go
if se, ok := rule.Type.(StateEmitter); ok {
    l.iteratorStack = append(l.iteratorStack, se.StateEmit(l))
} else if e, ok := rule.Type.(Emitter); ok {
    l.iteratorStack = append(l.iteratorStack, e.Emit(l.Groups, l.Lexer))
} else {
    panic(fmt.Sprintf("%v", rule.Type) + ` is not of type Emitter or StateEmitter.`)
}
```

But that didn't seem like a clean way to do it. So instead, I changed the API.