### PR TITLE
Fix: sort words in descending order of length before regex generation

### DIFF
--- a/lexers/r/raku.go
+++ b/lexers/r/raku.go
@@ -2,7 +2,6 @@ package r
 
 import (
 	"regexp"
-	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -70,7 +69,7 @@ func rakuRules() Rules {
 		`dynamic-scope`, `built`, `temp`,
 	}
 
-	keywordsPattern := Words(`(?<!['\w:-])`, `(?!['\w:-])`, sortWords(keywords)...)
+	keywordsPattern := Words(`(?<!['\w:-])`, `(?!['\w:-])`, keywords...)
 
 	wordOperators := []string{
 		`X`, `Z`, `R`, `after`, `and`, `andthen`, `before`, `cmp`, `div`, `eq`, `eqv`, `extra`, `ge`,
@@ -80,7 +79,7 @@ func rakuRules() Rules {
 		`(cont)`, `(<)`, `(<=)`, `(>)`, `(>=)`, `minmax`, `notandthen`, `S`,
 	}
 
-	wordOperatorsPattern := Words(`(?<=^|\b|\s)`, `(?=$|\b|\s)`, sortWords(wordOperators)...)
+	wordOperatorsPattern := Words(`(?<=^|\b|\s)`, `(?=$|\b|\s)`, wordOperators...)
 
 	operators := []string{
 		`++`, `--`, `-`, `**`, `!`, `+`, `~`, `?`, `+^`, `~^`, `?^`, `^`, `*`, `/`, `%`, `%%`, `+&`,
@@ -93,7 +92,7 @@ func rakuRules() Rules {
 		`⊃`, `⊅`, `⊇`, `⊉`, `:`, `!!!`, `???`, `¯`, `×`, `÷`, `−`, `⁺`, `⁻`,
 	}
 
-	operatorsPattern := Words(``, ``, sortWords(operators)...)
+	operatorsPattern := Words(``, ``, operators...)
 
 	builtinTypes := []string{
 		`False`, `True`, `Order`, `More`, `Less`, `Same`, `Any`, `Array`, `Associative`, `AST`,
@@ -142,7 +141,7 @@ func rakuRules() Rules {
 		`strict`, `trace`, `variables`,
 	}
 
-	builtinTypesPattern := Words(`(?<!['\w:-])`, `(?::[_UD])?(?!['\w:-])`, sortWords(builtinTypes)...)
+	builtinTypesPattern := Words(`(?<!['\w:-])`, `(?::[_UD])?(?!['\w:-])`, builtinTypes...)
 
 	builtinRoutines := []string{
 		`ACCEPTS`, `abs`, `abs2rel`, `absolute`, `accept`, `accepts_type`, `accessed`, `acos`,
@@ -266,7 +265,7 @@ func rakuRules() Rules {
 		`yyyy-mm-dd`, `z`, `zip`, `zip-latest`, `HOW`, `s`, `DEPRECATED`, `trait_mod`,
 	}
 
-	builtinRoutinesPattern := Words(`(?<!['\w:-])`, `(?!['\w-])`, sortWords(builtinRoutines)...)
+	builtinRoutinesPattern := Words(`(?<!['\w:-])`, `(?!['\w-])`, builtinRoutines...)
 
 	// A map of opening and closing brackets
 	brackets := map[rune]rune{
@@ -1195,15 +1194,6 @@ func joinRuneMap(m map[rune]rune) string {
 	}
 
 	return string(runes)
-}
-
-// Sorts words in descending order
-func sortWords(words []string) []string {
-	sort.Slice(words, func(i, j int) bool {
-		return len([]rune(words[i])) > len([]rune(words[j]))
-	})
-
-	return words
 }
 
 // Finds the index of substring in the string starting at position n

--- a/regexp.go
+++ b/regexp.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -139,6 +140,9 @@ func UsingSelf(state string) Emitter {
 
 // Words creates a regex that matches any of the given literal words.
 func Words(prefix, suffix string, words ...string) string {
+	sort.Slice(words, func(i, j int) bool {
+		return len(words[j]) < len(words[i])
+	})
 	for i, word := range words {
 		words[i] = regexp.QuoteMeta(word)
 	}


### PR DESCRIPTION
When generating the regex to match a string that belongs to a word list, and when one word of that list is a prefix of another, the former must come after the latter in the regex. This is because the regex parser is lazy about alternatives within a group, and stops at the first match; while the expected behavior is obviously greedy.

For instance (with keywords that can be found in Python): ```Words(``, ``, `yield`, `yield from`)``` without sorting would generate `(yield|yield from)`, a regex equivalent to `(yield)` (since when the ` from` suffix is here, the parser would stop after having matched `yield`).

A simple solution to solve this is to sort all words by descending length, which is sufficient to guarantee the aforementioned constraint.

*Performance note: it would be possible to imagine a more efficient solution at runtime by factoring the regex in order to group prefixes (and potentially even suffixes), and thus reducing the parser’s need for backtracking. For the discussed example, this would means generating `(yield(?: from)?)`. However, I don’t think it is worth it here, as this generation would be more complex and costly, while the total number of words is small, and the number of those with common prefixes is even smaller.*