### PR TITLE
Allow several tests for a same lexer

### DIFF
--- a/lexers/README.md
+++ b/lexers/README.md
@@ -3,6 +3,9 @@
 The tests in this directory feed a known input `testdata/<name>.actual` into the parser for `<name>` and check
 that its output matches `<name>.exported`.
 
+It is also possible to perform several tests on a same parser `<name>`, by placing know inputs `*.actual` into a
+directory `testdata/<name>/`.
+
 ## Running the tests
 
 Run the tests as normal:


### PR DESCRIPTION
This PR makes it possible to have several test files for a same lexer, by placing them in a directory—named after the lexer—in `testdata/`.

The underlying reasons for this PR are:
* make it easier to create independent tests for a same lexer, and therefore improve the overall robustness;
* make debugging easier in case of test failure (since it becomes possible to write different tests that test different features);
* allow easy import of [existing Pygments tests](https://github.com/pygments/pygments/tree/2.9.0/tests/snippets) into Chroma.