### PR TITLE
feat(lexers): match filenames ignoring trailing .in

### DIFF
--- a/lexers/internal/api.go
+++ b/lexers/internal/api.go
@@ -12,13 +12,15 @@ import (
 )
 
 var (
-	backupSuffixes = [...]string{
+	ignoredSuffixes = [...]string{
 		// Editor backups
 		"~", ".bak", ".old", ".orig",
-		// Debian and derivatives apt/dpkg
+		// Debian and derivatives apt/dpkg backups
 		".dpkg-dist", ".dpkg-old",
-		// Red Hat and derivatives rpm
+		// Red Hat and derivatives rpm backups
 		".rpmnew", ".rpmorig", ".rpmsave",
+		// Build system input/template files
+		".in",
 	}
 )
 
@@ -105,7 +107,7 @@ func Match(filename string) chroma.Lexer {
 			if fnmatch.Match(glob, filename, 0) {
 				matched = append(matched, lexer)
 			} else {
-				for _, suf := range &backupSuffixes {
+				for _, suf := range &ignoredSuffixes {
 					if fnmatch.Match(glob+suf, filename, 0) {
 						matched = append(matched, lexer)
 						break
@@ -126,7 +128,7 @@ func Match(filename string) chroma.Lexer {
 			if fnmatch.Match(glob, filename, 0) {
 				matched = append(matched, lexer)
 			} else {
-				for _, suf := range &backupSuffixes {
+				for _, suf := range &ignoredSuffixes {
 					if fnmatch.Match(glob+suf, filename, 0) {
 						matched = append(matched, lexer)
 						break


### PR DESCRIPTION
The .in suffix is often assiociated with build system input/template
files, for example in autotools ones.