### PR TITLE
feat(regexlexer): compile in RE2 compatibility mode

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -404,7 +404,7 @@ func (r *RegexLexer) maybeCompile() (err error) {
 					pattern = "(?" + rule.flags + ")" + pattern
 				}
 				pattern = `\G` + pattern
-				rule.Regexp, err = regexp2.Compile(pattern, 0)
+				rule.Regexp, err = regexp2.Compile(pattern, regexp2.RE2)
 				if err != nil {
 					return fmt.Errorf("failed to compile rule %s.%d: %s", state, i, err)
 				}


### PR DESCRIPTION
To better match vanilla Go regexps and support some additional
constructs that might be present in Pygments rules.

https://github.com/dlclark/regexp2#re2-compatibility-mode