### PR TITLE
WIP/RFC feat(lexers): add option to keep line splits on coalesce

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ mitigate this, you can use the coalescing lexer to coalesce runs of identical
 token types into a single token:
 
 ```go
-lexer = chroma.Coalesce(lexer)
+lexer = chroma.Coalesce(lexer, false)
 ```
 
 <a id="markdown-formatting-the-output" name="formatting-the-output"></a>
@@ -260,15 +260,22 @@ see documentation for the `LESSOPEN` environment variable.
 
 The `--fail` flag can be used to suppress output and return with exit status
 1 to facilitate falling back to some other preprocessor in case chroma
-does not resolve a specific lexer to use for the given file. For example:
+does not resolve a specific lexer to use for the given file.
+
+The `--keep-line-splits` option can be used to avoid coalescing consecutive
+tokens of the same type split at newlines. The default is to coalesce them,
+but that confuses `less` and may result in prematurely stopping colorise runs
+that should span multiple lines.
+
+For example:
 
 ```shell
-export LESSOPEN='| p() { chroma --fail "$1" || cat "$1"; }; p "%s"'
+export LESSOPEN='| p() { chroma --fail --keep-line-splits "$1" || cat "$1"; }; p "%s"'
 ```
 
 Replace `cat` with your favourite fallback preprocessor.
 
-When invoked as `.lessfilter`, the `--fail` flag is automatically turned
+When invoked as `.lessfilter`, the `--fail` and `--keep-line-splits` flags are automatically turned
 on under the hood for easy integration with [lesspipe shipping with
 Debian and derivatives](https://manpages.debian.org/lesspipe#USER_DEFINED_FILTERS);
 for that setup the `chroma` executable can be just symlinked to `~/.lessfilter`.

--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -38,14 +38,15 @@ command, for Go.
 `
 
 	cli struct {
-		Version    kong.VersionFlag `help:"Show version."`
-		Profile    string           `hidden:"" help:"Enable profiling to file."`
-		List       bool             `help:"List lexers, styles and formatters."`
-		Unbuffered bool             `help:"Do not buffer output."`
-		Trace      bool             `help:"Trace lexer states as they are traversed."`
-		Check      bool             `help:"Do not format, check for tokenisation errors instead."`
-		Filename   string           `help:"Filename to use for selecting a lexer when reading from stdin."`
-		Fail       bool             `help:"Exit silently with status 1 if no specific lexer was found."`
+		Version        kong.VersionFlag `help:"Show version."`
+		Profile        string           `hidden:"" help:"Enable profiling to file."`
+		List           bool             `help:"List lexers, styles and formatters."`
+		Unbuffered     bool             `help:"Do not buffer output."`
+		Trace          bool             `help:"Trace lexer states as they are traversed."`
+		Check          bool             `help:"Do not format, check for tokenisation errors instead."`
+		Filename       string           `help:"Filename to use for selecting a lexer when reading from stdin."`
+		Fail           bool             `help:"Exit silently with status 1 if no specific lexer was found."`
+		KeepLineSplits bool             `help:"Do not coalesce tokens at line splits."`
 
 		Lexer     string `help:"Lexer to use when formatting." default:"autodetect" short:"l" enum:"${lexers}"`
 		Style     string `help:"Style to use for formatting." default:"swapoff" short:"s" enum:"${styles}"`
@@ -159,6 +160,7 @@ func main() {
 	if path.Base(os.Args[0]) == ".lessfilter" {
 		// https://manpages.debian.org/lesspipe#USER_DEFINED_FILTERS
 		cli.Fail = true
+		cli.KeepLineSplits = true
 	}
 
 	var out io.Writer = os.Stdout
@@ -313,7 +315,7 @@ func lex(ctx *kong.Context, lexer chroma.Lexer, contents string) chroma.Iterator
 	if rel, ok := lexer.(*chroma.RegexLexer); ok {
 		rel.Trace(cli.Trace)
 	}
-	lexer = chroma.Coalesce(lexer)
+	lexer = chroma.Coalesce(lexer, cli.KeepLineSplits)
 	it, err := lexer.Tokenise(nil, contents)
 	ctx.FatalIfErrorf(err)
 	return it

--- a/coalesce.go
+++ b/coalesce.go
@@ -1,9 +1,12 @@
 package chroma
 
 // Coalesce is a Lexer interceptor that collapses runs of common types into a single token.
-func Coalesce(lexer Lexer) Lexer { return &coalescer{lexer} }
+func Coalesce(lexer Lexer, keepLineSplits bool) Lexer { return &coalescer{lexer, keepLineSplits} }
 
-type coalescer struct{ Lexer }
+type coalescer struct {
+	Lexer
+	keepLineSplits bool
+}
 
 func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, error) {
 	var prev Token
@@ -19,7 +22,7 @@ func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, e
 			if prev == EOF {
 				prev = token
 			} else {
-				if prev.Type == token.Type && len(prev.Value) < 8192 {
+				if prev.Type == token.Type && len(prev.Value) < 8192 && (!d.keepLineSplits || prev.Value[len(prev.Value)-1] != '\n') {
 					prev.Value += token.Value
 				} else {
 					out := prev

--- a/coalesce_test.go
+++ b/coalesce_test.go
@@ -11,9 +11,21 @@ func TestCoalesce(t *testing.T) {
 		"root": []Rule{
 			{`[!@#$%^&*()]`, Punctuation, nil},
 		},
-	}))
+	}), false)
 	actual, err := Tokenise(lexer, nil, "!@#$")
 	assert.NoError(t, err)
 	expected := []Token{{Punctuation, "!@#$"}}
+	assert.Equal(t, expected, actual)
+}
+
+func TestCoalesceKeepLineSplits(t *testing.T) {
+	lexer := Coalesce(MustNewLexer(nil, Rules{ // nolint: forbidigo
+		"root": []Rule{
+			{`.*\n`, Text, nil},
+		},
+	}), true)
+	actual, err := Tokenise(lexer, nil, "foo\nbar\n")
+	assert.NoError(t, err)
+	expected := []Token{{Text, "foo\n"}, {Text, "bar\n"}}
 	assert.Equal(t, expected, actual)
 }

--- a/delegate.go
+++ b/delegate.go
@@ -35,7 +35,7 @@ type insertion struct {
 }
 
 func (d *delegatingLexer) Tokenise(options *TokeniseOptions, text string) (Iterator, error) { // nolint: gocognit
-	tokens, err := Tokenise(Coalesce(d.language), options, text)
+	tokens, err := Tokenise(Coalesce(d.language, false), options, text)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +67,7 @@ func (d *delegatingLexer) Tokenise(options *TokeniseOptions, text string) (Itera
 	}
 
 	// Lex the other tokens.
-	rootTokens, err := Tokenise(Coalesce(d.root), options, others.String())
+	rootTokens, err := Tokenise(Coalesce(d.root, false), options, others.String())
 	if err != nil {
 		return nil, err
 	}

--- a/lexers/lexers_test.go
+++ b/lexers/lexers_test.go
@@ -102,7 +102,7 @@ func TestLexers(t *testing.T) {
 				filename := filepath.Join(dirname, subFile.Name())
 				expectedFilename := strings.TrimSuffix(filename, filepath.Ext(filename)) + ".expected"
 
-				lexer = chroma.Coalesce(lexer)
+				lexer = chroma.Coalesce(lexer, false)
 				FileTest(t, lexer, filename, expectedFilename)
 			}
 		} else {
@@ -118,7 +118,7 @@ func TestLexers(t *testing.T) {
 			filename := filepath.Join("testdata", file.Name())
 			expectedFilename := strings.TrimSuffix(filename, filepath.Ext(filename)) + ".expected"
 
-			lexer = chroma.Coalesce(lexer)
+			lexer = chroma.Coalesce(lexer, false)
 			FileTest(t, lexer, filename, expectedFilename)
 		}
 	}

--- a/quick/quick.go
+++ b/quick/quick.go
@@ -22,7 +22,7 @@ func Highlight(w io.Writer, source, lexer, formatter, style string) error {
 	if l == nil {
 		l = lexers.Fallback
 	}
-	l = chroma.Coalesce(l)
+	l = chroma.Coalesce(l, false)
 
 	// Determine formatter.
 	f := formatters.Get(formatter)

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -11,7 +11,7 @@ func TestNewlineAtEndOfFile(t *testing.T) {
 		"root": {
 			{`(\w+)(\n)`, ByGroups(Keyword, Whitespace), nil},
 		},
-	}))
+	}), false)
 	it, err := l.Tokenise(nil, `hello`)
 	assert.NoError(t, err)
 	assert.Equal(t, []Token{{Keyword, "hello"}, {Whitespace, "\n"}}, it.Tokens())
@@ -20,7 +20,7 @@ func TestNewlineAtEndOfFile(t *testing.T) {
 		"root": {
 			{`(\w+)(\n)`, ByGroups(Keyword, Whitespace), nil},
 		},
-	}))
+	}), false)
 	it, err = l.Tokenise(nil, `hello`)
 	assert.NoError(t, err)
 	assert.Equal(t, []Token{{Error, "hello"}}, it.Tokens())
@@ -36,7 +36,7 @@ func TestMatchingAtStart(t *testing.T) {
 		"directive": {
 			{"module", NameEntity, Pop(1)},
 		},
-	}))
+	}), false)
 	it, err := l.Tokenise(nil, `-module ->`)
 	assert.NoError(t, err)
 	assert.Equal(t,
@@ -49,7 +49,7 @@ func TestEnsureLFOption(t *testing.T) {
 		"root": {
 			{`(\w+)(\r?\n|\r)`, ByGroups(Keyword, Whitespace), nil},
 		},
-	}))
+	}), false)
 	it, err := l.Tokenise(&TokeniseOptions{
 		State:    "root",
 		EnsureLF: true,
@@ -66,7 +66,7 @@ func TestEnsureLFOption(t *testing.T) {
 		"root": {
 			{`(\w+)(\r?\n|\r)`, ByGroups(Keyword, Whitespace), nil},
 		},
-	}))
+	}), false)
 	it, err = l.Tokenise(&TokeniseOptions{
 		State:    "root",
 		EnsureLF: false,


### PR DESCRIPTION
`less` seems to get confused if a colorised run spans multiple lines, terminating the color at the first linefeed it sees. This adds a coalesce option to keep the line splits to avoid that issue.

This is mostly intended for discussion purposes, as this didn't turn out too pretty; it's mostly a PoC and my test if the anomalies were because of this.

It also does not help if a lexer already emits tokens containing linefeeds within it -- the coalesce phase is too late to tackle those. Would probably need an additional interceptor that actually "forcefully" splits emitted tokens at newlines before the coalescer. Or maybe we shouldn't use the coalescer at all in this special case, but just do the forceful token splits at newlines. Or something :)

Thoughts?