### PR TITLE
Added uint8_t to c lexer.

### DIFF
--- a/lexers/c/c.go
+++ b/lexers/c/c.go
@@ -43,7 +43,7 @@ func cRules() Rules {
 			{`[~!%^&*+=|?:<>/-]`, Operator, nil},
 			{`[()\[\],.]`, Punctuation, nil},
 			{Words(``, `\b`, `asm`, `auto`, `break`, `case`, `const`, `continue`, `default`, `do`, `else`, `enum`, `extern`, `for`, `goto`, `if`, `register`, `restricted`, `return`, `sizeof`, `static`, `struct`, `switch`, `typedef`, `union`, `volatile`, `while`), Keyword, nil},
-			{`(bool|int|long|float|short|double|char|unsigned|signed|void)\b`, KeywordType, nil},
+			{`(bool|int|long|float|short|double|char((8|16|32)_t)?|unsigned|signed|void|u?int(_fast|_least|)(8|16|32|64)_t)\b`, KeywordType, nil},
 			{Words(``, `\b`, `inline`, `_inline`, `__inline`, `naked`, `restrict`, `thread`, `typename`), KeywordReserved, nil},
 			{`(__m(128i|128d|128|64))\b`, KeywordReserved, nil},
 			{Words(`__`, `\b`, `asm`, `int8`, `based`, `except`, `int16`, `stdcall`, `cdecl`, `fastcall`, `int32`, `declspec`, `finally`, `int64`, `try`, `leave`, `wchar_t`, `w64`, `unaligned`, `raise`, `noop`, `identifier`, `forceinline`, `assume`), KeywordReserved, nil},


### PR DESCRIPTION
Copied the KeywordType rule from the c++ lexer (but removed wchar_t since it doesn't exist in c).

Unfortunately, I can't test it since I'm unfamiliar with go.