### PR TITLE
fish: Fix incorrect tokenisation of command arguments containing dash

### DIFF
--- a/lexers/f/fish.go
+++ b/lexers/f/fish.go
@@ -74,7 +74,7 @@ func fishRules() Rules {
 			{`&&|\|\||&|\||\^|<|>`, Operator, nil},
 			{`\s+`, Text, nil},
 			{`\b\d+\b`, LiteralNumber, nil},
-			{`--?[^\d][\w-]*`, NameAttribute, nil},
+			{`(?<=\s+)--?[^\d][\w-]*`, NameAttribute, nil},
 			{".+?", Text, nil},
 		},
 		"string": {

--- a/lexers/testdata/fish.actual
+++ b/lexers/testdata/fish.actual
@@ -24,6 +24,8 @@ set data (cat data | string split0)
 
 grep fish myanimallist1 | wc -l
 
+command some-arg-with-dash
+
 echo input.{c,h,txt}
 
 echo {$dogs}dog

--- a/lexers/testdata/fish.expected
+++ b/lexers/testdata/fish.expected
@@ -94,6 +94,8 @@
   {"type":"Text","value":" "},
   {"type":"NameAttribute","value":"-l"},
   {"type":"Text","value":"\n\n"},
+  {"type":"NameBuiltin","value":"command "},
+  {"type":"Text","value":"some-arg-with-dash\n\n"},
   {"type":"Keyword","value":"echo"},
   {"type":"Text","value":" input."},
   {"type":"Operator","value":"{"},
@@ -865,7 +867,7 @@
   {"type":"Text","value":" "},
   {"type":"Operator","value":"("},
   {"type":"NameBuiltin","value":"status fish"},
-  {"type":"NameAttribute","value":"-path"},
+  {"type":"Text","value":"-path"},
   {"type":"Operator","value":")"},
   {"type":"Text","value":"\n                "},
   {"type":"Keyword","value":"set"},
@@ -1261,5 +1263,6 @@
   {"type":"Text","value":" "},
   {"type":"LiteralNumber","value":"0"},
   {"type":"Text","value":"\n    "},
-  {"type":"Keyword","value":"end"}
+  {"type":"Keyword","value":"end"},
+  {"type":"Text","value":"\n"}
 ]


### PR DESCRIPTION
Command line arguments containing dash/hyphen were incorrectly tokenised as command line options.