### PR TITLE
lexers: add Debian user configuration file backups to ignored suffixes

### DIFF
--- a/lexers/internal/api.go
+++ b/lexers/internal/api.go
@@ -15,8 +15,8 @@ var (
 	ignoredSuffixes = [...]string{
 		// Editor backups
 		"~", ".bak", ".old", ".orig",
-		// Debian and derivatives apt/dpkg backups
-		".dpkg-dist", ".dpkg-old",
+		// Debian and derivatives apt/dpkg/ucf backups
+		".dpkg-dist", ".dpkg-old", ".ucf-dist", ".ucf-new", ".ucf-old",
 		// Red Hat and derivatives rpm backups
 		".rpmnew", ".rpmorig", ".rpmsave",
 		// Build system input/template files


### PR DESCRIPTION
https://manpages.debian.b/bullseye/ucf/ucf.1.en.html