### PR TITLE
lexers/internal: remove danwakefield/fnmatch

### DIFF
--- a/lexers/internal/api.go
+++ b/lexers/internal/api.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/danwakefield/fnmatch"
-
 	"github.com/alecthomas/chroma"
 )
 
@@ -104,11 +102,17 @@ func Match(filename string) chroma.Lexer {
 	for _, lexer := range Registry.Lexers {
 		config := lexer.Config()
 		for _, glob := range config.Filenames {
-			if fnmatch.Match(glob, filename, 0) {
+			ok, err := filepath.Match(glob, filename)
+			if err != nil {
+				panic(err)
+			} else if ok {
 				matched = append(matched, lexer)
 			} else {
 				for _, suf := range &ignoredSuffixes {
-					if fnmatch.Match(glob+suf, filename, 0) {
+					ok, err := filepath.Match(glob+suf, filename)
+					if err != nil {
+						panic(err)
+					} else if ok {
 						matched = append(matched, lexer)
 						break
 					}
@@ -125,11 +129,17 @@ func Match(filename string) chroma.Lexer {
 	for _, lexer := range Registry.Lexers {
 		config := lexer.Config()
 		for _, glob := range config.AliasFilenames {
-			if fnmatch.Match(glob, filename, 0) {
+			ok, err := filepath.Match(glob, filename)
+			if err != nil {
+				panic(err)
+			} else if ok {
 				matched = append(matched, lexer)
 			} else {
 				for _, suf := range &ignoredSuffixes {
-					if fnmatch.Match(glob+suf, filename, 0) {
+					ok, err := filepath.Match(glob+suf, filename)
+					if err != nil {
+						panic(err)
+					} else if ok {
 						matched = append(matched, lexer)
 						break
 					}


### PR DESCRIPTION
This package appears to be old and unmaintained, and it gets pulled into the go.sum of every single package importing Chroma. Also fnmatch doesnt seem to do any error checking on the pattern, while the standard package does. Also, the standard package `path/filepath` is already imported, so it appears not to cost anything to change it.