### PR TITLE
[HTML formatter] Use `span` for `.line`, put code inside `<code>`

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -139,17 +139,17 @@ var (
 	defaultPreWrapper = preWrapper{
 		start: func(code bool, styleAttr string) string {
 			if code {
-				return fmt.Sprintf(`<pre tabindex="0"%s>`, styleAttr)
+				return fmt.Sprintf(`<pre tabindex="0"%s><code>`, styleAttr)
 			}
 
-			return fmt.Sprintf(`<div tabindex="0"%s>`, styleAttr)
+			return fmt.Sprintf(`<pre tabindex="0"%s>`, styleAttr)
 		},
 		end: func(code bool) string {
 			if code {
-				return `</pre>`
+				return `</code></pre>`
 			}
 
-			return `</div>`
+			return `</pre>`
 		},
 	}
 )
@@ -250,7 +250,7 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 		}
 
 		// Start of Line
-		fmt.Fprint(w, `<div`)
+		fmt.Fprint(w, `<span`)
 		if highlight {
 			// Line + LineHighlight
 			if f.Classes {
@@ -281,7 +281,7 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 
 		fmt.Fprint(w, `</span>`) // End of CodeLine
 
-		fmt.Fprint(w, `</div>`) // End of Line
+		fmt.Fprint(w, `</span>`) // End of Line
 	}
 
 	fmt.Fprintf(w, f.preWrapper.End(true))
@@ -454,8 +454,8 @@ func (f *Formatter) styleToCSS(style *chroma.Style) map[chroma.TokenType]string 
 	// All rules begin with default rules followed by user provided rules
 	classes[chroma.Line] = `display: flex;` + classes[chroma.Line]
 	classes[chroma.LineNumbers] = lineNumbersStyle + classes[chroma.LineNumbers]
-	classes[chroma.LineNumbersTable] = `font-family: monospace; font-size: inherit;` + lineNumbersStyle + classes[chroma.LineNumbersTable]
-	classes[chroma.LineTable] = "border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block;" + classes[chroma.LineTable]
+	classes[chroma.LineNumbersTable] = lineNumbersStyle + classes[chroma.LineNumbersTable]
+	classes[chroma.LineTable] = "border-spacing: 0; padding: 0; margin: 0; border: 0;" + classes[chroma.LineTable]
 	classes[chroma.LineTableTD] = "vertical-align: top; padding: 0; margin: 0; border: 0;" + classes[chroma.LineTableTD]
 	return classes
 }

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -129,7 +129,7 @@ func TestHighlightLines(t *testing.T) {
 	err = f.Format(&buf, styles.Fallback, it)
 	assert.NoError(t, err)
 
-	assert.Contains(t, buf.String(), `<div class="line hl"><span class="cl">`)
+	assert.Contains(t, buf.String(), `<span class="line hl"><span class="cl">`)
 }
 
 func TestLineNumbers(t *testing.T) {
@@ -141,7 +141,7 @@ func TestLineNumbers(t *testing.T) {
 	err = f.Format(&buf, styles.Fallback, it)
 	assert.NoError(t, err)
 
-	assert.Contains(t, buf.String(), `<div class="line"><span class="ln">1</span><span class="cl"><span class="nb">echo</span> FOO</span></div>`)
+	assert.Contains(t, buf.String(), `<span class="line"><span class="ln">1</span><span class="cl"><span class="nb">echo</span> FOO</span></span>`)
 }
 
 func TestPreWrapper(t *testing.T) {
@@ -153,7 +153,7 @@ func TestPreWrapper(t *testing.T) {
 	err = f.Format(&buf, styles.Fallback, it)
 	assert.NoError(t, err)
 
-	assert.Regexp(t, "<body class=\"bg\">\n<pre.*class=\"chroma\"><div class=\"line\"><span class=\"cl\"><span class=\"nb\">echo</span> FOO</span></div></pre>\n</body>\n</html>", buf.String())
+	assert.Regexp(t, "<body class=\"bg\">\n<pre.*class=\"chroma\"><code><span class=\"line\"><span class=\"cl\"><span class=\"nb\">echo</span> FOO</span></span></code></pre>\n</body>\n</html>", buf.String())
 	assert.Regexp(t, `\.bg { .+ }`, buf.String())
 	assert.Regexp(t, `\.chroma { .+ }`, buf.String())
 }
@@ -252,17 +252,17 @@ func TestWithPreWrapper(t *testing.T) {
 
 	t.Run("Regular", func(t *testing.T) {
 		s := format(New(WithClasses(true)))
-		assert.Equal(t, s, `<pre tabindex="0" class="chroma"><div class="line"><span class="cl"><span class="nb">echo</span> FOO</span></div></pre>`)
+		assert.Equal(t, s, `<pre tabindex="0" class="chroma"><code><span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span></code></pre>`)
 	})
 
 	t.Run("PreventSurroundingPre", func(t *testing.T) {
 		s := format(New(PreventSurroundingPre(true), WithClasses(true)))
-		assert.Equal(t, s, `<div class="line"><span class="cl"><span class="nb">echo</span> FOO</span></div>`)
+		assert.Equal(t, s, `<span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span>`)
 	})
 
 	t.Run("Wrapper", func(t *testing.T) {
 		s := format(New(WithPreWrapper(wrapper), WithClasses(true)))
-		assert.Equal(t, s, `<foo class="chroma" id="code-true"><div class="line"><span class="cl"><span class="nb">echo</span> FOO</span></div></foo>`)
+		assert.Equal(t, s, `<foo class="chroma" id="code-true"><span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span></foo>`)
 	})
 
 	t.Run("Wrapper, LineNumbersInTable", func(t *testing.T) {
@@ -273,7 +273,7 @@ func TestWithPreWrapper(t *testing.T) {
 <foo class="chroma" id="code-false"><span class="lnt">1
 </span></foo></td>
 <td class="lntd">
-<foo class="chroma" id="code-true"><div class="line"><span class="cl"><span class="nb">echo</span> FOO</span></div></foo></td></tr></table>
+<foo class="chroma" id="code-true"><span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span></foo></td></tr></table>
 </div>
 `)
 	})
@@ -296,7 +296,7 @@ func TestReconfigureOptions(t *testing.T) {
 	err = f.Format(&buf, styles.Fallback, it)
 
 	assert.NoError(t, err)
-	assert.Equal(t, `<pre tabindex="0" class="chroma"><div class="line"><span class="cl"><span class="nb">echo</span> FOO</span></div></pre>`, buf.String())
+	assert.Equal(t, `<pre tabindex="0" class="chroma"><code><span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span></code></pre>`, buf.String())
 }
 
 func TestWriteCssWithAllClasses(t *testing.T) {


### PR DESCRIPTION
Apparently only "phrasing content" are permitted inside `pre` and `code`, and `div` is not one of them, so replaced it with `span`, `div` wasn't necessary anyway.

Also it makes sense to put code inside `code` tag(except for line numbers).

Removed `overflow:auto` and `width: auto` from `table` as they didn't seem to be necessary and actually prevented horizontal scroll bar to appear when content didn't fit in the viewport.