### PR TITLE
updated mimetype for biceps

### DIFF
--- a/lexers/b/bicep.go
+++ b/lexers/b/bicep.go
@@ -13,7 +13,7 @@ var Bicep = internal.Register(MustNewLazyLexer(
 		Name:      "Bicep",
 		Aliases:   []string{"bicep"},
 		Filenames: []string{"*.bicep"},
-		MimeTypes: []string{"application/x-bicep"},
+		MimeTypes: []string{"text/plain"},
 	},
 	bicepRules,
 ))


### PR DESCRIPTION
Based on the highlighted answer from the Biceps team in the discussion (https://github.com/Azure/bicep/discussions/4939), the mimetype was reduced to `text/plain`.