### PR TITLE
Removed mimetype for the Lexer bicep

### DIFF
--- a/lexers/b/bicep.go
+++ b/lexers/b/bicep.go
@@ -13,7 +13,6 @@ var Bicep = internal.Register(MustNewLazyLexer(
 		Name:      "Bicep",
 		Aliases:   []string{"bicep"},
 		Filenames: []string{"*.bicep"},
-		MimeTypes: []string{"text/plain"},
 	},
 	bicepRules,
 ))

--- a/lexers/b/bicep.go
+++ b/lexers/b/bicep.go
@@ -13,7 +13,7 @@ var Bicep = internal.Register(MustNewLazyLexer(
 		Name:      "Bicep",
 		Aliases:   []string{"bicep"},
 		Filenames: []string{"*.bicep"},
-		MimeTypes: []string{"application/x-bicep"},
+		MimeTypes: []string{"text/plain"},
 	},
 	bicepRules,
 ))


### PR DESCRIPTION
As discussed in the other PR #573, the MimeType for the Lexer Bicep has been removed.