### PR TITLE
Fixed scheme characters

### DIFF
--- a/lexers/s/scheme.go
+++ b/lexers/s/scheme.go
@@ -30,7 +30,7 @@ func schemeLangRules() Rules {
 			{`-?\d+`, LiteralNumberInteger, nil},
 			{`"(\\\\|\\"|[^"])*"`, LiteralString, nil},
 			{`'[\w!$%&*+,/:<=>?@^~|-]+`, LiteralStringSymbol, nil},
-			{`#\\([()/'\"._!§$%& ?=+-]|[a-zA-Z0-9]+)`, LiteralStringChar, nil},
+			{`#\\(alarm|backspace|delete|esc|linefeed|newline|page|return|space|tab|vtab|x[0-9a-zA-Z]{1,5}|.)`, LiteralStringChar, nil},
 			{`(#t|#f)`, NameConstant, nil},
 			{"('|#|`|,@|,|\\.)", Operator, nil},
 			{`(lambda |define |if |else |cond |and |or |case |let |let\* |letrec |begin |do |delay |set\! |\=\> |quote |quasiquote |unquote |unquote\-splicing |define\-syntax |let\-syntax |letrec\-syntax |syntax\-rules )`, Keyword, nil},


### PR DESCRIPTION
Currently, some characters are not detected and some strings are detected as characters while they shouldn't. Example from the playground :
![image](https://user-images.githubusercontent.com/1546678/145737554-3463ca65-d5b9-4d5f-8939-55c43be9d133.png)

This PR fixes this. Example from running patched chroma binary in a terminal :
![image](https://user-images.githubusercontent.com/1546678/145737643-f8e2618e-d649-4ca9-95bb-ffd698bf87d9.png)