### PR TITLE
Highlight MSBuild project files for C#, F#, and C++ as XML.

### DIFF
--- a/lexers/x/xml.go
+++ b/lexers/x/xml.go
@@ -10,7 +10,7 @@ var XML = internal.Register(MustNewLazyLexer(
 	&Config{
 		Name:      "XML",
 		Aliases:   []string{"xml"},
-		Filenames: []string{"*.xml", "*.xsl", "*.rss", "*.xslt", "*.xsd", "*.wsdl", "*.wsf", "*.svg", "*.csproj", "*.vcxproj"},
+		Filenames: []string{"*.xml", "*.xsl", "*.rss", "*.xslt", "*.xsd", "*.wsdl", "*.wsf", "*.svg", "*.csproj", "*.vcxproj", "*.fsproj"},
 		MimeTypes: []string{"text/xml", "application/xml", "image/svg+xml", "application/rss+xml", "application/atom+xml"},
 		DotAll:    true,
 	},

--- a/lexers/x/xml.go
+++ b/lexers/x/xml.go
@@ -10,7 +10,7 @@ var XML = internal.Register(MustNewLazyLexer(
 	&Config{
 		Name:      "XML",
 		Aliases:   []string{"xml"},
-		Filenames: []string{"*.xml", "*.xsl", "*.rss", "*.xslt", "*.xsd", "*.wsdl", "*.wsf", "*.svg"},
+		Filenames: []string{"*.xml", "*.xsl", "*.rss", "*.xslt", "*.xsd", "*.wsdl", "*.wsf", "*.svg", "*.csproj", "*.vcxproj"},
 		MimeTypes: []string{"text/xml", "application/xml", "image/svg+xml", "application/rss+xml", "application/atom+xml"},
 		DotAll:    true,
 	},


### PR DESCRIPTION
Add support for highlighting MSBuild project files for C# (.csproj), F# (.fsproj), and C++ (.vcxproj), which are XML based.

Reference:
* https://docs.microsoft.com/en-us/cpp/build/reference/vcxproj-file-structure?view=msvc-170
* https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview#project-files