### PR TITLE
Update friendly.go

### DIFF
--- a/styles/friendly.go
+++ b/styles/friendly.go
@@ -29,7 +29,7 @@ var Friendly = Register(chroma.MustNewStyle("friendly", chroma.StyleEntries{
 	chroma.NameDecorator:         "bold #555555",
 	chroma.LiteralString:         "#4070a0",
 	chroma.LiteralStringDoc:      "italic",
-	chroma.LiteralStringInterpol: "italic #70a0d0",
+	chroma.LiteralStringInterpol: "#70a0d0",
 	chroma.LiteralStringEscape:   "bold #4070a0",
 	chroma.LiteralStringRegex:    "#235388",
 	chroma.LiteralStringSymbol:   "#517918",


### PR DESCRIPTION
Remove italic for friendly style in chroma.LiteralStringInterpol. 
Purpose: For python it make a mistake in code style.
![chroma-friendly-style](https://user-images.githubusercontent.com/35261782/150443449-8566ec86-43aa-43b0-bef3-318ae86c5a13.png)

