### PR TITLE
Fix priority for PHTML and PHP

### DIFF
--- a/lexers/circular/php.go
+++ b/lexers/circular/php.go
@@ -15,6 +15,7 @@ var PHP = internal.Register(MustNewLazyLexer(
 		DotAll:          true,
 		CaseInsensitive: true,
 		EnsureNL:        true,
+		Priority:        1,
 	},
 	phpRules,
 ))

--- a/lexers/circular/phtml.go
+++ b/lexers/circular/phtml.go
@@ -18,7 +18,7 @@ var PHTML = internal.Register(DelegatingLexer(h.HTML, MustNewLazyLexer(
 		DotAll:          true,
 		CaseInsensitive: true,
 		EnsureNL:        true,
-		Priority:        2,
+		Priority:        0.9,
 	},
 	phtmlRules,
 ).SetAnalyser(func(text string) float32 {


### PR DESCRIPTION
This PR fixed the PHTML priority taken over PHP. It was based on `v0.10.0` since the latest version 2 is still in beta.

Fixes https://github.com/alecthomas/chroma/issues/577