### PR TITLE
fix: revert line change from pygments converter 59896e35

### DIFF
--- a/_tools/pygments2chroma.py
+++ b/_tools/pygments2chroma.py
@@ -191,7 +191,6 @@ def main():
         name=lexer_cls.name,
         regex_flags=lexer_cls.flags,
         upper_name=to_camel_case(re.sub(r'\W', '_', lexer_cls.name)),
-        upper_name=to_camel_case(re.sub(r'\W', '_', lexer_cls.name)),
         aliases=lexer_cls.aliases,
         filenames=lexer_cls.filenames,
         mimetypes=lexer_cls.mimetypes,


### PR DESCRIPTION
Link to the breaking change: [L194](https://github.com/alecthomas/chroma/commit/59896e35\#diff-636cb338885284f1ed8524116f49b2bffcae81cfce89f55719019c993007d209R194)

I assume this is an accident that was overlooked for a few weeks.