### PR TITLE
Add `InlineCode` option for inline code blocks

### DIFF
--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -296,7 +296,17 @@ func TestWithPreWrapper(t *testing.T) {
 
 	t.Run("PreventSurroundingPre", func(t *testing.T) {
 		s := format(New(PreventSurroundingPre(true), WithClasses(true)))
-		assert.Equal(t, s, `<span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span>`)
+		assert.Equal(t, s, `<span class="nb">echo</span> FOO`)
+	})
+
+	t.Run("InlineCode", func(t *testing.T) {
+		s := format(New(InlineCode(true), WithClasses(true)))
+		assert.Equal(t, s, `<code class="chroma"><span class="nb">echo</span> FOO</code>`)
+	})
+
+	t.Run("InlineCode, inline styles", func(t *testing.T) {
+		s := format(New(InlineCode(true)))
+		assert.Regexp(t, `<code style=".+?"><span style=".+?">echo</span> FOO</code>`, s)
 	})
 
 	t.Run("Wrapper", func(t *testing.T) {


### PR DESCRIPTION
- Add an `InlineCode` option for inline code blocks, which wraps the code in `code` tag and doesn't wrap the code by `Line` and `CodeLine`
- When `PreventSurroundingPre` option is enabled, do not wrap the code by `Line` and `CodeLine`
- Write and update related tests
- Fixes #617

Please test and review if this behavior is desired and correct.

Specially `PreventSurroundingPre`, is everyone OK with this behavior?