### PR TITLE
Allow calculating the original token lengths

### DIFF
--- a/coalesce.go
+++ b/coalesce.go
@@ -1,16 +1,24 @@
 package chroma
 
+import (
+	"fmt"
+)
+
 // Coalesce is a Lexer interceptor that collapses runs of common types into a single token.
 func Coalesce(lexer Lexer) Lexer { return &coalescer{lexer} }
 
 type coalescer struct{ Lexer }
 
 func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, error) {
-	var prev Token
 	it, err := d.Lexer.Tokenise(options, text)
 	if err != nil {
 		return nil, err
 	}
+	return d.iter(it), nil
+}
+
+func (d *coalescer) iter(it func() Token) func() Token {
+	var prev Token
 	return func() Token {
 		for token := it(); token != (EOF); token = it() {
 			if len(token.Value) == 0 {
@@ -31,5 +39,21 @@ func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, e
 		out := prev
 		prev = EOF
 		return out
-	}, nil
+	}
+}
+
+func (d *coalescer) TokeniseWithOriginalLen(options *TokeniseOptions, text string) (Iterator, OriginalLenIterator, error) {
+	lex, ok := d.Lexer.(TokeniserWithOriginalLen)
+
+	if !ok {
+		err := fmt.Errorf("lexer does not support tokenizing with offsets")
+		return nil, OriginalLenIterator{}, err
+	}
+
+	it, offsetIter, err := lex.TokeniseWithOriginalLen(options, text)
+	if err != nil {
+		return nil, OriginalLenIterator{}, err
+	}
+
+	return d.iter(it), offsetIter, nil
 }

--- a/lexer.go
+++ b/lexer.go
@@ -110,6 +110,10 @@ type Lexer interface {
 	AnalyseText(text string) float32
 }
 
+type TokeniserWithOriginalLen interface {
+	TokeniseWithOriginalLen(options *TokeniseOptions, text string) (Iterator, OriginalLenIterator, error)
+}
+
 // Lexers is a slice of lexers sortable by name.
 type Lexers []Lexer
 


### PR DESCRIPTION
When carriage returns are stripped from the input text, the length of
the token values no longer equals the length of the tokens in the
original text. This change adds a struct that can be used to recover the
original lengths.

Fixes alecthomas#619