### PR TITLE
Add support for F# open static class

### DIFF
--- a/lexers/embedded/fsharp.xml
+++ b/lexers/embedded/fsharp.xml
@@ -133,7 +133,7 @@
         <token type="LiteralString"/>
         <push state="string"/>
       </rule>
-      <rule pattern="\b(open|module)(\s+)([\w.]+)">
+      <rule pattern="\b(open type|open|module)(\s+)([\w.]+)">
         <bygroups>
           <token type="Keyword"/>
           <token type="Text"/>

--- a/lexers/testdata/fsharp/fsharp_open_static_class.actual
+++ b/lexers/testdata/fsharp/fsharp_open_static_class.actual
@@ -1,0 +1,4 @@
+open type System.Math
+
+module A =
+    open type System.Math

--- a/lexers/testdata/fsharp/fsharp_open_static_class.expected
+++ b/lexers/testdata/fsharp/fsharp_open_static_class.expected
@@ -1,0 +1,16 @@
+[
+  {"type":"Keyword","value":"open type"},
+  {"type":"Text","value":" "},
+  {"type":"NameNamespace","value":"System.Math"},
+  {"type":"Text","value":"\n\n"},
+  {"type":"Keyword","value":"module"},
+  {"type":"Text","value":" "},
+  {"type":"NameNamespace","value":"A"},
+  {"type":"Text","value":" "},
+  {"type":"Operator","value":"="},
+  {"type":"Text","value":"\n    "},
+  {"type":"Keyword","value":"open type"},
+  {"type":"Text","value":" "},
+  {"type":"NameNamespace","value":"System.Math"},
+  {"type":"Text","value":"\n"}
+]


### PR DESCRIPTION
Hello,

*Disclaimer: I am new to Go, so I am unsure if what I did is all that is needed*

In F# it is now possible to open static class using `open type` syntax. 
[F# documentation](https://docs.microsoft.com/fr-fr/dotnet/fsharp/language-reference/import-declarations-the-open-keyword#open-type-declarations)

This PR tries to add support for this syntax.

In the test code, that I used I wanted to check that it the highlith worked for both top level instruction and instructions indented inside of a module.

