### PR TITLE
Revise fortran fixed format lexer to recognize comments specified using the "!"

### DIFF
--- a/lexers/fortran_fixed.go
+++ b/lexers/fortran_fixed.go
@@ -19,18 +19,18 @@ var FortranFixed = Register(MustNewLexer(
 			"root": {
 				{`[C*].*\n`, Comment, nil},
 				{`#.*\n`, CommentPreproc, nil},
-				{`[\t ]*!.*\n`, Comment, nil},
+				{` {0,4}!.*\n`, Comment, nil},
 				{`(.{5})`, NameLabel, Push("cont-char")},
 				{`.*\n`, Using("Fortran"), nil},
 			},
 			"cont-char": {
-				{` `, Text, Push("code")},
-				{`0`, Comment, Push("code")},
+				{` `, TextWhitespace, Push("code")},
 				{`.`, GenericStrong, Push("code")},
 			},
 			"code": {
-				{`(.{66})(.*)(\n)`, ByGroups(Using("Fortran"), Comment, Text), Push("root")},
-				{`.*\n`, Using("Fortran"), Push("root")},
+				{`(.{66})(.*)(\n)`, ByGroups(Using("Fortran"), Comment, TextWhitespace), Push("root")},
+				{`(.*)(!.*)(\n)`, ByGroups(Using("Fortran"), Comment, TextWhitespace), Push("root")},
+				{`(.*)(\n)`, ByGroups(Using("Fortran"), TextWhitespace), Push("root")},
 				Default(Push("root")),
 			},
 		}


### PR DESCRIPTION
Revise fortran fixed format lexer to recognize comments declared using the "!" mark. When "!" occurs in any column other than 6 (i.e. columns 1-5 and columns > 6) it is the start of a comment.  Removed incorrect "0" label being a comment.