### PR TITLE
Add Dockerfile.* to docker lexer

### DIFF
--- a/lexers/docker.go
+++ b/lexers/docker.go
@@ -9,7 +9,7 @@ var Docker = Register(MustNewLexer(
 	&Config{
 		Name:            "Docker",
 		Aliases:         []string{"docker", "dockerfile"},
-		Filenames:       []string{"Dockerfile", "*.docker"},
+		Filenames:       []string{"Dockerfile", "Dockerfile.*", "*.docker"},
 		MimeTypes:       []string{"text/x-dockerfile-config"},
 		CaseInsensitive: true,
 	},


### PR DESCRIPTION
It's a rather common practice to use this naming pattern when multiple Dockerfiles are present.