### PR TITLE
Add cjs to Javascript lexer

### DIFF
--- a/lexers/embedded/javascript.xml
+++ b/lexers/embedded/javascript.xml
@@ -6,6 +6,7 @@
     <filename>*.js</filename>
     <filename>*.jsm</filename>
     <filename>*.mjs</filename>
+    <filename>*.cjs</filename>
     <mime_type>application/javascript</mime_type>
     <mime_type>application/x-javascript</mime_type>
     <mime_type>text/x-javascript</mime_type>


### PR DESCRIPTION
.cjs is used to indicate a CommonJS in Node.js and other tools