### PR TITLE
cfengine3: Removed rule attempting to highlight variable names

### DIFF
--- a/lexers/embedded/cfengine3.xml
+++ b/lexers/embedded/cfengine3.xml
@@ -70,18 +70,6 @@
           <token type="NameFunction"/>
         </bygroups>
       </rule>
-      <rule pattern="(&#34;)([^&#34;]+)(&#34;)(\s+)(string|slist|int|real)(\s*)(=&gt;)(\s*)">
-        <bygroups>
-          <token type="Punctuation"/>
-          <token type="NameVariable"/>
-          <token type="Punctuation"/>
-          <token type="Text"/>
-          <token type="KeywordType"/>
-          <token type="Text"/>
-          <token type="Operator"/>
-          <token type="Text"/>
-        </bygroups>
-      </rule>
       <rule pattern="(\S+)(\s*)(=&gt;)(\s*)">
         <bygroups>
           <token type="KeywordReserved"/>


### PR DESCRIPTION
This rule is problematic for 2 reasons:
* The regex is buggy, it doesn't work for more advanced cases
  when there are other attributes before slist, or string, or
  whatever the type is.
* In the context of CFEngine policy language, it's just a bit
  confusing. Yes, they are variable names, but they are also
  quoted strings, and what we call promisers. It looks better,
  more consistent and less confusing if they are highlighted
  in the same way as other strings and promisers.

**Before:**

![before](https://user-images.githubusercontent.com/4048546/184380696-57ea920b-9408-4210-b0a0-cf12fbc2cabb.png)

**After:**

![after](https://user-images.githubusercontent.com/4048546/184380715-ef7fabc2-17be-47c8-9ebe-067dfa362406.png)