### PR TITLE
Add lexer for properties files

### DIFF
--- a/lexers/embedded/properties.xml
+++ b/lexers/embedded/properties.xml
@@ -1,0 +1,27 @@
+<lexer>
+  <config>
+    <name>properties</name>
+    <alias>java-properties</alias>
+    <filename>*.properties</filename>
+    <mime_type>text/x-java-properties</mime_type>
+  </config>
+  <rules>
+    <state name="root">
+      <rule pattern="\s+">
+        <token type="Text"/>
+      </rule>
+      <rule pattern="^[;#!].*">
+        <token type="CommentSingle"/>
+      </rule>
+      <rule pattern="^(.+?)([ \t]*)([=:])([ \t]*)(.*)">
+        <bygroups>
+          <token type="NameAttribute"/>
+          <token type="Text"/>
+          <token type="Operator"/>
+          <token type="Text"/>
+          <token type="LiteralString"/>
+        </bygroups>
+      </rule>
+    </state>
+  </rules>
+</lexer>


### PR DESCRIPTION
Properties files are very common in Java projects (see https://en.wikipedia.org/wiki/.properties)

Known limitations of my lexer:
- Multi line entries with trailing backspaces won't be detected (I don't know your lexer syntax well enough to solve this)
- `key value` entries without `=` and `:` won't be detected (I have never seen such entries in real life)

Fixes #615