### PR TITLE
Improved PowerShell lexer

### DIFF
--- a/lexers/embedded/powershell.xml
+++ b/lexers/embedded/powershell.xml
@@ -119,6 +119,9 @@
         <token type="Punctuation"/>
         <push state="child"/>
       </rule>
+      <rule pattern="(\$)((global|script|private|env):)?\w+">
+        <token type="NameVariable"/>
+      </rule>
       <rule pattern="&#34;&#34;">
         <token type="LiteralStringDouble"/>
       </rule>
@@ -138,6 +141,9 @@
       <rule pattern="\$\(">
         <token type="Punctuation"/>
         <push state="child"/>
+      </rule>
+      <rule pattern="(\$)((global|script|private|env):)?\w+">
+        <token type="NameVariable"/>
       </rule>
       <rule pattern="[^@\n]+&#34;]">
         <token type="LiteralStringHeredoc"/>

--- a/lexers/testdata/powershell.actual
+++ b/lexers/testdata/powershell.actual
@@ -1,1 +1,5 @@
 Get-ChildItem -Recurse -Force -ErrorAction SilentlyContinue -Name -Path C:\ *.txt
+$x = "Here is a $var inside a string"
+$x = @"
+Here is a $var inside a here-string
+"@

--- a/lexers/testdata/powershell.expected
+++ b/lexers/testdata/powershell.expected
@@ -18,5 +18,20 @@
   {"type":"Text","value":" "},
   {"type":"Punctuation","value":"*."},
   {"type":"Name","value":"txt"},
-  {"type":"Text","value":"\n"}
+  {"type":"Text","value":"\n"},
+  {"type":"NameVariable","value":"$x"},
+  {"type":"Text","value":" "},
+  {"type":"Punctuation","value":"="},
+  {"type":"Text","value":" "},
+  {"type":"LiteralStringDouble","value":"\"Here is a "},
+  {"type":"NameVariable","value":"$var"},
+  {"type":"LiteralStringDouble","value":" inside a string\""},
+  {"type":"Text","value":"\n"},
+  {"type":"NameVariable","value":"$x"},
+  {"type":"Text","value":" "},
+  {"type":"Punctuation","value":"="},
+  {"type":"Text","value":" "},
+  {"type":"LiteralStringHeredoc","value":"@\"\nHere is a "},
+  {"type":"NameVariable","value":"$var"},
+  {"type":"LiteralStringHeredoc","value":" inside a here-string\n\"@"}
 ]


### PR DESCRIPTION
Problem:
Variables inside doublequoted strings were not highlighted properly in PowerShell. The variables looked like they do when using singlequoted strings.

Solution:
Added rules and tests for variables inside doublequoted strings in PowerShell.

It took me a while to understand how the lexers work, but I think I have understood it properly. I could not find any contributing guidelines so I hope I have not broken any rules now :)