### PR TITLE
Fix a bug that ate functions on C lexer

### DIFF
--- a/lexers/embedded/c.xml
+++ b/lexers/embedded/c.xml
@@ -218,6 +218,9 @@
           <token type="Punctuation"/>
         </bygroups>
       </rule>
+      <rule pattern="\b[A-Za-z_]\w*(?=\s*\()">
+          <token type="NameFunction"/>
+      </rule>
       <rule pattern="[a-zA-Z_]\w*">
         <token type="Name"/>
       </rule>
@@ -226,7 +229,7 @@
       <rule>
         <include state="whitespace"/>
       </rule>
-      <rule pattern="((?:[\w*\s])+?(?:\s|[*]))([a-zA-Z_]\w*)(\s*\([^;]*?\))([^;{]*)(\{)|\b[a-z_]\w*(?=\s*\()">
+      <rule pattern="((?:[\w*\s])+?(?:\s|[*]))([a-zA-Z_]\w*)(\s*\([^;]*?\))([^;{]*)(\{)">
         <bygroups>
           <usingself state="root"/>
           <token type="NameFunction"/>


### PR DESCRIPTION
Sorry, I was wrong on #701 This should fix the problem of not highlighting functions.
See the screenshot below:
![image](https://user-images.githubusercontent.com/27734319/201172188-ad710d4c-e45a-40f9-a99e-8965c6e6fa40.png)
