### PR TITLE
Add systemd .service and .socket to ini lexer

### DIFF
--- a/lexers/embedded/ini.xml
+++ b/lexers/embedded/ini.xml
@@ -7,6 +7,8 @@
     <filename>*.ini</filename>
     <filename>*.cfg</filename>
     <filename>*.inf</filename>
+    <filename>*.service</filename>
+    <filename>*.socket</filename>
     <filename>.gitconfig</filename>
     <filename>.editorconfig</filename>
     <filename>pylintrc</filename>


### PR DESCRIPTION
I think these should be pretty un-ambigous. There are more systemd-related file extensions, but I'm less sure about them, so I left them out.

Ref: https://www.freedesktop.org/software/systemd/man/systemd.unit.html