### PR TITLE
lexers: Add benchmark for lexers.Get

### DIFF
--- a/lexers/lexers_test.go
+++ b/lexers/lexers_test.go
@@ -193,3 +193,17 @@ func TestLexersTextAnalyser(t *testing.T) {
 		FileTestAnalysis(t, lexer, actualFilepath, expectedFilepath)
 	}
 }
+
+func BenchmarkLexersGet(b *testing.B) {
+	b.Run("Known", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lexers.Get("go")
+		}
+	})
+
+	b.Run("Unknown", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lexers.Get("unknown")
+		}
+	})
+}


### PR DESCRIPTION
```
BenchmarkLexersGet/Known-10             112448803            10.57 ns/op           0 B/op           0 allocs/op
BenchmarkLexersGet/Unknown-10                286       4160740 ns/op           0 B/op           0 allocs/op
```
