### PR TITLE
Adds NoTabindex and TabindexValue configs

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -72,6 +72,8 @@ command, for Go.
 		HTMLBaseLine              int    `group:"html" help:"Base line number." default:"1"`
 		HTMLPreventSurroundingPre bool   `group:"html" help:"Prevent the surrounding pre tag."`
 		HTMLLinkableLines         bool   `group:"html" help:"Make the line numbers linkable and be a link to themselves."`
+		HTMLNoTabindex            bool   `group:"html" help:"Remove the 'tabindex' attribute from HTML <pre> elements." default:"false"`
+		HTMLTabindexValue         int    `group:"html" help:"The value of the 'tabindex' attribute for HTML <pre> elements." default:"0"`
 
 		Files []string `arg:"" optional:"" help:"Files to highlight." type:"existingfile"`
 	}
@@ -265,6 +267,8 @@ func configureHTMLFormatter(ctx *kong.Context) {
 		html.LineNumbersInTable(cli.HTMLLinesTable),
 		html.PreventSurroundingPre(cli.HTMLPreventSurroundingPre),
 		html.WithLinkableLineNumbers(cli.HTMLLinkableLines, "L"),
+		html.NoTabIndex(cli.HTMLNoTabindex),
+		html.TabIndexValue(cli.HTMLTabindexValue),
 	}
 	if len(cli.HTMLHighlight) > 0 {
 		ranges := [][2]int{}

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -272,7 +272,7 @@ func TestTableLineNumberSpacing(t *testing.T) {
 
 func TestWithPreWrapper(t *testing.T) {
 	wrapper := preWrapper{
-		start: func(code bool, styleAttr string) string {
+		start: func(code bool, tabIndexAttr bool, tabIndexValue int, styleAttr string) string {
 			return fmt.Sprintf("<foo%s id=\"code-%t\">", styleAttr, code)
 		},
 		end: func(code bool) string {
@@ -299,6 +299,16 @@ func TestWithPreWrapper(t *testing.T) {
 	t.Run("PreventSurroundingPre", func(t *testing.T) {
 		s := format(New(PreventSurroundingPre(true), WithClasses(true)))
 		assert.Equal(t, s, `<span class="nb">echo</span> FOO`)
+	})
+
+	t.Run("PreventTabIndex", func(t *testing.T) {
+		s := format(New(NoTabIndex(true), WithClasses(true)))
+		assert.Equal(t, s, `<pre class="chroma"><code><span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span></code></pre>`)
+	})
+
+	t.Run("OverrideTabIndex", func(t *testing.T) {
+		s := format(New(TabIndexValue(-1), WithClasses(true)))
+		assert.Equal(t, s, `<pre tabindex="-1" class="chroma"><code><span class="line"><span class="cl"><span class="nb">echo</span> FOO</span></span></code></pre>`)
 	})
 
 	t.Run("InlineCode", func(t *testing.T) {


### PR DESCRIPTION
By default, Chroma adds `tabindex="0"` to HTML's `<pre>` elements, which makes `<pre>` elements navigatable via keyboard in the browser ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex)).

This PR preserves the default behavior to ensure backward compatibility. It introduces two new options to control the `tabindex` attribute:

* `--html-no-tabindex`/`NoTabIndex(b bool)`: Remove the 'tabindex' attribute from HTML `<pre>` elements. Defaults to false.
*  `--html-tabindex-value`/`TabIndexValue(n int)`: The value of the 'tabindex' attribute for HTML `<pre>` elements. Defaults to 0.

Fixes #731 