### PR TITLE
increase php priority over phtml

### DIFF
--- a/lexers/embedded/php.xml
+++ b/lexers/embedded/php.xml
@@ -12,6 +12,7 @@
     <case_insensitive>true</case_insensitive>
     <dot_all>true</dot_all>
     <ensure_nl>true</ensure_nl>
+    <priority>3</priority>
   </config>
   <rules>
     <state name="magicfuncs">


### PR DESCRIPTION
currently phtml takes priority over php, that's odd considering phtml is not very common anymore compared to php

Fixes #577 