### PR TITLE
Add Gitignore lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ C | C, C#, C++, Caddyfile, Caddyfile Directives, Cap'n Proto, Cassandra CQL, Cey
 D | D, Dart, Diff, Django/Jinja, Docker, DTD, Dylan
 E | EBNF, Elixir, Elm, EmacsLisp, Erlang
 F | Factor, Fish, Forth, Fortran, FSharp
-G | GAS, GDScript, Genshi, Genshi HTML, Genshi Text, Gherkin, GLSL, Gnuplot, Go, Go HTML Template, Go Text Template, GraphQL, Groff, Groovy
+G | GAS, GDScript, Genshi, Genshi HTML, Genshi Text, Gherkin, Gitignore, GLSL, Gnuplot, Go, Go HTML Template, Go Text Template, GraphQL, Groff, Groovy
 H | Handlebars, Haskell, Haxe, HCL, Hexdump, HLB, HLSL, HTML, HTTP, Hy
 I | Idris, Igor, INI, Io
 J | J, Java, JavaScript, JSON, Julia, Jungle

--- a/lexers/embedded/gitignore.xml
+++ b/lexers/embedded/gitignore.xml
@@ -1,0 +1,13 @@
+<lexer>
+  <config>
+    <name>Gitignore</name>
+    <filename>.gitignore</filename>
+  </config>
+  <rules>
+    <state name="root">
+      <rule pattern="^#.*">
+        <token type="CommentSingle"/>
+      </rule>
+    </state>
+  </rules>
+</lexer>

--- a/lexers/testdata/gitignore.actual
+++ b/lexers/testdata/gitignore.actual
@@ -1,0 +1,4 @@
+test
+
+# comment
+test2

--- a/lexers/testdata/gitignore.expected
+++ b/lexers/testdata/gitignore.expected
@@ -1,0 +1,5 @@
+[
+  {"type":"Error","value":"test\n\n"},
+  {"type":"CommentSingle","value":"# comment"},
+  {"type":"Error","value":"\ntest2\n"}
+]


### PR DESCRIPTION
This adds a Lexer for .gitignore file. It just highlights the comments. There is not much more to do.