### PR TITLE
Fix Playground on Windows

### DIFF
--- a/cmd/chromad/main.go
+++ b/cmd/chromad/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"html/template"
 	"log"
+	"mime"
 	"net/http"
 	"sort"
 	"strings"
@@ -180,6 +181,8 @@ func main() {
 	ctx := kong.Parse(&cli, kong.Configuration(konghcl.Loader), kong.Vars{"version": version})
 
 	log.Printf("Starting chromad %s on http://%s\n", version, cli.Bind)
+
+	mime.AddExtensionType(".js", "application/javascript")
 
 	router := mux.NewRouter()
 	router.Handle("/", http.HandlerFunc(index)).Methods("GET")


### PR DESCRIPTION
While testing on a VM, if the steps described in #757  also works on Windows, I found out, that the Playground is broken. The reason is, that it doesn't use the correct mime type for JavaScript for some reason. This fixes it.