### PR TITLE
cfengine3 xml: add $(..) to match NameVariable

### DIFF
--- a/lexers/embedded/cfengine3.xml
+++ b/lexers/embedded/cfengine3.xml
@@ -111,6 +111,9 @@
       <rule pattern="@[{(][^)}]+[})]">
         <token type="NameVariable"/>
       </rule>
+      <rule pattern="\$[(][^)]+[)]">
+        <token type="NameVariable"/>
+      </rule>
       <rule pattern="[(){},;]">
         <token type="Punctuation"/>
       </rule>


### PR DESCRIPTION
$(...) is a valid syntax (believe called nakedvar) that should also be
matched by the CFEngine3 lexer.

Fixes: #767

Signed-off-by: Miek Gieben <miek@miek.nl>
