### PR TITLE
FIX: update nord theme to have a base color for NameOther

### DIFF
--- a/styles/nord.xml
+++ b/styles/nord.xml
@@ -15,6 +15,7 @@
   <entry type="NameFunction" style="#88c0d0"/>
   <entry type="NameLabel" style="#8fbcbb"/>
   <entry type="NameNamespace" style="#8fbcbb"/>
+  <entry type="NameOther" style="#d8dee9"/>
   <entry type="NameTag" style="#81a1c1"/>
   <entry type="NameVariable" style="#d8dee9"/>
   <entry type="LiteralString" style="#a3be8c"/>


### PR DESCRIPTION
Right now there is no value for NameOther making .chroma .nx to be empty.

Because of that there are cases in which the color is wrongly used because it's not overwritten (for eg: when trying to use a light theme as the main one, and Nord under prefers-color-scheme: dark .

This MR sets the color to match the one from the theme preview.

Before:
![image](https://user-images.githubusercontent.com/51180/235369808-65cfe2ad-be0e-4132-a674-8ea1d92077f9.png)
After:
![image](https://user-images.githubusercontent.com/51180/235369814-5ef486a0-cee4-4dc0-8f1e-344cc6e6d9d7.png)
