### PR TITLE
FIX: update nord theme to have a base color for NameProperty

### DIFF
--- a/styles/nord.xml
+++ b/styles/nord.xml
@@ -18,6 +18,7 @@
   <entry type="NameOther" style="#d8dee9"/>
   <entry type="NameTag" style="#81a1c1"/>
   <entry type="NameVariable" style="#d8dee9"/>
+  <entry type="NameProperty" style="#8fbcbb"/>
   <entry type="LiteralString" style="#a3be8c"/>
   <entry type="LiteralStringDoc" style="#616e87"/>
   <entry type="LiteralStringEscape" style="#ebcb8b"/>


### PR DESCRIPTION
Right now there is no value for NameProperty making .chroma .py to be empty.

Because of that there are cases in which the color is wrongly used because it's not overwritten (for eg: when trying to use a light theme as the main one, and Nord under prefers-color-scheme: dark .

This sets the color to match the one from the theme preview that is applied for the methods

Before:
![image](https://user-images.githubusercontent.com/51180/235513565-2be87708-2d16-4164-890c-dc0ba141fe40.png)
After:
![image](https://user-images.githubusercontent.com/51180/235513574-c0c4cef0-0988-417e-a134-178a515f3430.png)
