### PR TITLE
proposal: Add `TokeniseStream` support

### DIFF
--- a/coalesce.go
+++ b/coalesce.go
@@ -1,5 +1,9 @@
 package chroma
 
+import (
+	"io"
+)
+
 // Coalesce is a Lexer interceptor that collapses runs of common types into a single token.
 func Coalesce(lexer Lexer) Lexer { return &coalescer{lexer} }
 
@@ -8,6 +12,35 @@ type coalescer struct{ Lexer }
 func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, error) {
 	var prev Token
 	it, err := d.Lexer.Tokenise(options, text)
+	if err != nil {
+		return nil, err
+	}
+	return func() Token {
+		for token := it(); token != (EOF); token = it() {
+			if len(token.Value) == 0 {
+				continue
+			}
+			if prev == EOF {
+				prev = token
+			} else {
+				if prev.Type == token.Type && len(prev.Value) < 8192 {
+					prev.Value += token.Value
+				} else {
+					out := prev
+					prev = token
+					return out
+				}
+			}
+		}
+		out := prev
+		prev = EOF
+		return out
+	}, nil
+}
+
+func (d *coalescer) TokeniseStream(options *TokeniseOptions, textReader io.Reader, blockSize, textSize int) (Iterator, error) {
+	var prev Token
+	it, err := d.Lexer.TokeniseStream(options, textReader, blockSize, textSize)
 	if err != nil {
 		return nil, err
 	}

--- a/delegate_test.go
+++ b/delegate_test.go
@@ -1,6 +1,7 @@
 package chroma
 
 import (
+	"strings"
 	"testing"
 
 	assert "github.com/alecthomas/assert/v2"
@@ -103,6 +104,18 @@ func TestDelegate(t *testing.T) {
 		// nolint: scopelint
 		t.Run(test.name, func(t *testing.T) {
 			it, err := delegate.Tokenise(nil, test.source)
+			assert.NoError(t, err)
+			actual := it.Tokens()
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+
+	for _, test := range testdata {
+		// nolint: scopelint
+		t.Run(test.name, func(t *testing.T) {
+			code := strings.NewReader(test.source)
+
+			it, err := delegate.TokeniseStream(nil, code, 20, int(code.Size()))
 			assert.NoError(t, err)
 			actual := it.Tokens()
 			assert.Equal(t, test.expected, actual)

--- a/lexer.go
+++ b/lexer.go
@@ -2,6 +2,7 @@ package chroma
 
 import (
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -108,6 +109,8 @@ type Lexer interface {
 	// AnalyseText scores how likely a fragment of text is to match
 	// this lexer, between 0.0 and 1.0. A value of 1 indicates high confidence.
 	AnalyseText(text string) float32
+	// TokeniseStream returns an Iterator over tokens in text reader.
+	TokeniseStream(options *TokeniseOptions, textReader io.Reader, blockSize, textSize int) (Iterator, error)
 }
 
 // Lexers is a slice of lexers sortable by name.


### PR DESCRIPTION
TokeniseStream allow user `Tokenise` with a file reader and the total size of this file reader instead of the all content. it will read the file block by block when needed.

new params of `TokeniseStream`:

- `textReader`: `io.Reader`: the reader of `text`
- `blockSize`: `int`: read buffer size
- `textSize`: size of all `text`

when will read the file:
- all readen data wa handled (POS > len)
- can't match any groups and `l.Pos != 0`

example usage: https://github.com/a1012112796/gitea/commit/93a5d885e35a03744ac51f6fa1d3cb796e91f3f8