### PR TITLE
Update Catppuccin Colors

### DIFF
--- a/styles/catppuccin-frappe.xml
+++ b/styles/catppuccin-frappe.xml
@@ -1,46 +1,83 @@
 <style name="catppuccin-frappe">
+  <entry type="Background" style="bg:#303446 #c6d0f5"/>
+  <entry type="CodeLine" style="#c6d0f5"/>
   <entry type="Error" style="#e78284"/>
-  <entry type="Background" style="#ef9f76 bg:#303446"/>
+  <entry type="Other" style="#c6d0f5"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="#51576d"/>
+  <entry type="LineNumbersTable" style="#838ba7"/>
+  <entry type="LineNumbers" style="#838ba7"/>
   <entry type="Keyword" style="#ca9ee6"/>
-  <entry type="KeywordConstant" style="italic #ca9ee6"/>
-  <entry type="KeywordPseudo" style="bold #ca9ee6"/>
-  <entry type="KeywordType" style="#e5c890"/>
-  <entry type="Name" style="#babbf1"/>
-  <entry type="NameAttribute" style="#e5c890"/>
-  <entry type="NameBuiltin" style="italic #c6d0f5"/>
+  <entry type="KeywordReserved" style="#ca9ee6"/>
+  <entry type="KeywordPseudo" style="#ca9ee6"/>
+  <entry type="KeywordConstant" style="#ef9f76"/>
+  <entry type="KeywordDeclaration" style="#e78284"/>
+  <entry type="KeywordNamespace" style="#81c8be"/>
+  <entry type="KeywordType" style="#e78284"/>
+  <entry type="Name" style="#c6d0f5"/>
   <entry type="NameClass" style="#e5c890"/>
   <entry type="NameConstant" style="#e5c890"/>
-  <entry type="NameDecorator" style="#f4b8e4"/>
-  <entry type="NameEntity" style="#f4b8e4"/>
-  <entry type="NameException" style="#ea999c"/>
-  <entry type="NameFunction" style="#99d1db"/>
-  <entry type="NameLabel" style="#e5c890"/>
-  <entry type="NameNamespace" style="#e5c890"/>
-  <entry type="NameOther" style="#ef9f76"/>
+  <entry type="NameDecorator" style="bold #8caaee"/>
+  <entry type="NameEntity" style="#81c8be"/>
+  <entry type="NameException" style="#ef9f76"/>
+  <entry type="NameFunction" style="#8caaee"/>
+  <entry type="NameFunctionMagic" style="#8caaee"/>
+  <entry type="NameLabel" style="#99d1db"/>
+  <entry type="NameNamespace" style="#ef9f76"/>
+  <entry type="NameProperty" style="#ef9f76"/>
   <entry type="NameTag" style="#ca9ee6"/>
-  <entry type="NameVariable" style="#ef9f76"/>
+  <entry type="NameVariable" style="#f2d5cf"/>
+  <entry type="NameVariableClass" style="#f2d5cf"/>
+  <entry type="NameVariableGlobal" style="#f2d5cf"/>
+  <entry type="NameVariableInstance" style="#f2d5cf"/>
+  <entry type="NameVariableMagic" style="#f2d5cf"/>
+  <entry type="NameAttribute" style="#8caaee"/>
+  <entry type="NameBuiltin" style="#99d1db"/>
+  <entry type="NameBuiltinPseudo" style="#99d1db"/>
+  <entry type="NameOther" style="#c6d0f5"/>
+  <entry type="Literal" style="#c6d0f5"/>
+  <entry type="LiteralDate" style="#c6d0f5"/>
   <entry type="LiteralString" style="#a6d189"/>
-  <entry type="LiteralStringDoc" style="#a6d189"/>
-  <entry type="LiteralStringEscape" style="#8caaee"/>
-  <entry type="LiteralStringInterpol" style="#a6d189"/>
+  <entry type="LiteralStringChar" style="#a6d189"/>
+  <entry type="LiteralStringSingle" style="#a6d189"/>
+  <entry type="LiteralStringDouble" style="#a6d189"/>
+  <entry type="LiteralStringBacktick" style="#a6d189"/>
   <entry type="LiteralStringOther" style="#a6d189"/>
-  <entry type="LiteralStringRegex" style="#8caaee"/>
   <entry type="LiteralStringSymbol" style="#a6d189"/>
+  <entry type="LiteralStringInterpol" style="#a6d189"/>
+  <entry type="LiteralStringAffix" style="#e78284"/>
+  <entry type="LiteralStringDelimiter" style="#8caaee"/>
+  <entry type="LiteralStringEscape" style="#8caaee"/>
+  <entry type="LiteralStringRegex" style="#81c8be"/>
+  <entry type="LiteralStringDoc" style="#737994"/>
+  <entry type="LiteralStringHeredoc" style="#737994"/>
   <entry type="LiteralNumber" style="#ef9f76"/>
-  <entry type="Operator" style="#99d1db"/>
+  <entry type="LiteralNumberBin" style="#ef9f76"/>
+  <entry type="LiteralNumberHex" style="#ef9f76"/>
+  <entry type="LiteralNumberInteger" style="#ef9f76"/>
+  <entry type="LiteralNumberFloat" style="#ef9f76"/>
+  <entry type="LiteralNumberIntegerLong" style="#ef9f76"/>
+  <entry type="LiteralNumberOct" style="#ef9f76"/>
+  <entry type="Operator" style="bold #99d1db"/>
   <entry type="OperatorWord" style="bold #99d1db"/>
-  <entry type="Punctuation" style="#c6d0f5"/>
-  <entry type="Comment" style="italic #626880"/>
-  <entry type="CommentPreproc" style="#8caaee"/>
-  <entry type="GenericDeleted" style="#ea999c"/>
-  <entry type="GenericEmph" style="italic"/>
-  <entry type="GenericError" style="#ea999c"/>
-  <entry type="GenericHeading" style="bold #99d1db"/>
-  <entry type="GenericInserted" style="#a6d189"/>
-  <entry type="GenericOutput" style="#ef9f76"/>
-  <entry type="GenericPrompt" style="bold #737994"/>
-  <entry type="GenericStrong" style="bold"/>
-  <entry type="GenericSubheading" style="bold #99d1db"/>
-  <entry type="GenericTraceback" style="#ea999c"/>
-  <entry type="TextWhitespace" style="#414559"/>
+  <entry type="Comment" style="italic #737994"/>
+  <entry type="CommentSingle" style="italic #737994"/>
+  <entry type="CommentMultiline" style="italic #737994"/>
+  <entry type="CommentSpecial" style="italic #737994"/>
+  <entry type="CommentHashbang" style="italic #737994"/>
+  <entry type="CommentPreproc" style="italic #737994"/>
+  <entry type="CommentPreprocFile" style="bold #737994"/>
+  <entry type="Generic" style="#c6d0f5"/>
+  <entry type="GenericInserted" style="bg:#414559 #a6d189"/>
+  <entry type="GenericDeleted" style="#e78284 bg:#414559"/>
+  <entry type="GenericEmph" style="italic #c6d0f5"/>
+  <entry type="GenericStrong" style="bold #c6d0f5"/>
+  <entry type="GenericUnderline" style="underline #c6d0f5"/>
+  <entry type="GenericHeading" style="bold #ef9f76"/>
+  <entry type="GenericSubheading" style="bold #ef9f76"/>
+  <entry type="GenericOutput" style="#c6d0f5"/>
+  <entry type="GenericPrompt" style="#c6d0f5"/>
+  <entry type="GenericError" style="#e78284"/>
+  <entry type="GenericTraceback" style="#e78284"/>
 </style>

--- a/styles/catppuccin-latte.xml
+++ b/styles/catppuccin-latte.xml
@@ -1,46 +1,83 @@
 <style name="catppuccin-latte">
+  <entry type="Background" style="bg:#eff1f5 #4c4f69"/>
+  <entry type="CodeLine" style="#4c4f69"/>
   <entry type="Error" style="#d20f39"/>
-  <entry type="Background" style="#fe640b bg:#eff1f5"/>
+  <entry type="Other" style="#4c4f69"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="#bcc0cc"/>
+  <entry type="LineNumbersTable" style="#8c8fa1"/>
+  <entry type="LineNumbers" style="#8c8fa1"/>
   <entry type="Keyword" style="#8839ef"/>
-  <entry type="KeywordConstant" style="italic #8839ef"/>
-  <entry type="KeywordPseudo" style="bold #8839ef"/>
-  <entry type="KeywordType" style="#df8e1d"/>
-  <entry type="Name" style="#7287fd"/>
-  <entry type="NameAttribute" style="#df8e1d"/>
-  <entry type="NameBuiltin" style="italic #fe640b"/>
+  <entry type="KeywordReserved" style="#8839ef"/>
+  <entry type="KeywordPseudo" style="#8839ef"/>
+  <entry type="KeywordConstant" style="#fe640b"/>
+  <entry type="KeywordDeclaration" style="#d20f39"/>
+  <entry type="KeywordNamespace" style="#179299"/>
+  <entry type="KeywordType" style="#d20f39"/>
+  <entry type="Name" style="#4c4f69"/>
   <entry type="NameClass" style="#df8e1d"/>
   <entry type="NameConstant" style="#df8e1d"/>
-  <entry type="NameDecorator" style="#ea76cb"/>
-  <entry type="NameEntity" style="#ea76cb"/>
-  <entry type="NameException" style="#e64553"/>
-  <entry type="NameFunction" style="#04a5e5"/>
-  <entry type="NameLabel" style="#df8e1d"/>
-  <entry type="NameNamespace" style="#df8e1d"/>
-  <entry type="NameOther" style="#fe640b"/>
+  <entry type="NameDecorator" style="bold #1e66f5"/>
+  <entry type="NameEntity" style="#179299"/>
+  <entry type="NameException" style="#fe640b"/>
+  <entry type="NameFunction" style="#1e66f5"/>
+  <entry type="NameFunctionMagic" style="#1e66f5"/>
+  <entry type="NameLabel" style="#04a5e5"/>
+  <entry type="NameNamespace" style="#fe640b"/>
+  <entry type="NameProperty" style="#fe640b"/>
   <entry type="NameTag" style="#8839ef"/>
-  <entry type="NameVariable" style="#fe640b"/>
+  <entry type="NameVariable" style="#dc8a78"/>
+  <entry type="NameVariableClass" style="#dc8a78"/>
+  <entry type="NameVariableGlobal" style="#dc8a78"/>
+  <entry type="NameVariableInstance" style="#dc8a78"/>
+  <entry type="NameVariableMagic" style="#dc8a78"/>
+  <entry type="NameAttribute" style="#1e66f5"/>
+  <entry type="NameBuiltin" style="#04a5e5"/>
+  <entry type="NameBuiltinPseudo" style="#04a5e5"/>
+  <entry type="NameOther" style="#4c4f69"/>
+  <entry type="Literal" style="#4c4f69"/>
+  <entry type="LiteralDate" style="#4c4f69"/>
   <entry type="LiteralString" style="#40a02b"/>
-  <entry type="LiteralStringDoc" style="#40a02b"/>
-  <entry type="LiteralStringEscape" style="#1e66f5"/>
-  <entry type="LiteralStringInterpol" style="#40a02b"/>
+  <entry type="LiteralStringChar" style="#40a02b"/>
+  <entry type="LiteralStringSingle" style="#40a02b"/>
+  <entry type="LiteralStringDouble" style="#40a02b"/>
+  <entry type="LiteralStringBacktick" style="#40a02b"/>
   <entry type="LiteralStringOther" style="#40a02b"/>
-  <entry type="LiteralStringRegex" style="#1e66f5"/>
   <entry type="LiteralStringSymbol" style="#40a02b"/>
+  <entry type="LiteralStringInterpol" style="#40a02b"/>
+  <entry type="LiteralStringAffix" style="#d20f39"/>
+  <entry type="LiteralStringDelimiter" style="#1e66f5"/>
+  <entry type="LiteralStringEscape" style="#1e66f5"/>
+  <entry type="LiteralStringRegex" style="#179299"/>
+  <entry type="LiteralStringDoc" style="#9ca0b0"/>
+  <entry type="LiteralStringHeredoc" style="#9ca0b0"/>
   <entry type="LiteralNumber" style="#fe640b"/>
-  <entry type="Operator" style="#04a5e5"/>
+  <entry type="LiteralNumberBin" style="#fe640b"/>
+  <entry type="LiteralNumberHex" style="#fe640b"/>
+  <entry type="LiteralNumberInteger" style="#fe640b"/>
+  <entry type="LiteralNumberFloat" style="#fe640b"/>
+  <entry type="LiteralNumberIntegerLong" style="#fe640b"/>
+  <entry type="LiteralNumberOct" style="#fe640b"/>
+  <entry type="Operator" style="bold #04a5e5"/>
   <entry type="OperatorWord" style="bold #04a5e5"/>
-  <entry type="Punctuation" style="#4c4f69"/>
-  <entry type="Comment" style="italic #acb0be"/>
-  <entry type="CommentPreproc" style="#1e66f5"/>
-  <entry type="GenericDeleted" style="#e64553"/>
-  <entry type="GenericEmph" style="italic"/>
-  <entry type="GenericError" style="#e64553"/>
-  <entry type="GenericHeading" style="bold #04a5e5"/>
-  <entry type="GenericInserted" style="#40a02b"/>
-  <entry type="GenericOutput" style="#fe640b"/>
-  <entry type="GenericPrompt" style="bold #9ca0b0"/>
-  <entry type="GenericStrong" style="bold"/>
-  <entry type="GenericSubheading" style="bold #04a5e5"/>
-  <entry type="GenericTraceback" style="#e64553"/>
-  <entry type="TextWhitespace" style="#ccd0da"/>
+  <entry type="Comment" style="italic #9ca0b0"/>
+  <entry type="CommentSingle" style="italic #9ca0b0"/>
+  <entry type="CommentMultiline" style="italic #9ca0b0"/>
+  <entry type="CommentSpecial" style="italic #9ca0b0"/>
+  <entry type="CommentHashbang" style="italic #9ca0b0"/>
+  <entry type="CommentPreproc" style="italic #9ca0b0"/>
+  <entry type="CommentPreprocFile" style="bold #9ca0b0"/>
+  <entry type="Generic" style="#4c4f69"/>
+  <entry type="GenericInserted" style="bg:#ccd0da #40a02b"/>
+  <entry type="GenericDeleted" style="#d20f39 bg:#ccd0da"/>
+  <entry type="GenericEmph" style="italic #4c4f69"/>
+  <entry type="GenericStrong" style="bold #4c4f69"/>
+  <entry type="GenericUnderline" style="underline #4c4f69"/>
+  <entry type="GenericHeading" style="bold #fe640b"/>
+  <entry type="GenericSubheading" style="bold #fe640b"/>
+  <entry type="GenericOutput" style="#4c4f69"/>
+  <entry type="GenericPrompt" style="#4c4f69"/>
+  <entry type="GenericError" style="#d20f39"/>
+  <entry type="GenericTraceback" style="#d20f39"/>
 </style>

--- a/styles/catppuccin-macchiato.xml
+++ b/styles/catppuccin-macchiato.xml
@@ -1,46 +1,83 @@
 <style name="catppuccin-macchiato">
+  <entry type="Background" style="bg:#24273a #cad3f5"/>
+  <entry type="CodeLine" style="#cad3f5"/>
   <entry type="Error" style="#ed8796"/>
-  <entry type="Background" style="#f5a97f bg:#24273a"/>
+  <entry type="Other" style="#cad3f5"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="#494d64"/>
+  <entry type="LineNumbersTable" style="#8087a2"/>
+  <entry type="LineNumbers" style="#8087a2"/>
   <entry type="Keyword" style="#c6a0f6"/>
-  <entry type="KeywordConstant" style="italic #c6a0f6"/>
-  <entry type="KeywordPseudo" style="bold #c6a0f6"/>
-  <entry type="KeywordType" style="#eed49f"/>
-  <entry type="Name" style="#b7bdf8"/>
-  <entry type="NameAttribute" style="#eed49f"/>
-  <entry type="NameBuiltin" style="italic #f5a97f"/>
+  <entry type="KeywordReserved" style="#c6a0f6"/>
+  <entry type="KeywordPseudo" style="#c6a0f6"/>
+  <entry type="KeywordConstant" style="#f5a97f"/>
+  <entry type="KeywordDeclaration" style="#ed8796"/>
+  <entry type="KeywordNamespace" style="#8bd5ca"/>
+  <entry type="KeywordType" style="#ed8796"/>
+  <entry type="Name" style="#cad3f5"/>
   <entry type="NameClass" style="#eed49f"/>
   <entry type="NameConstant" style="#eed49f"/>
-  <entry type="NameDecorator" style="#f5bde6"/>
-  <entry type="NameEntity" style="#f5bde6"/>
-  <entry type="NameException" style="#ee99a0"/>
-  <entry type="NameFunction" style="#91d7e3"/>
-  <entry type="NameLabel" style="#eed49f"/>
-  <entry type="NameNamespace" style="#eed49f"/>
-  <entry type="NameOther" style="#f5a97f"/>
+  <entry type="NameDecorator" style="bold #8aadf4"/>
+  <entry type="NameEntity" style="#8bd5ca"/>
+  <entry type="NameException" style="#f5a97f"/>
+  <entry type="NameFunction" style="#8aadf4"/>
+  <entry type="NameFunctionMagic" style="#8aadf4"/>
+  <entry type="NameLabel" style="#91d7e3"/>
+  <entry type="NameNamespace" style="#f5a97f"/>
+  <entry type="NameProperty" style="#f5a97f"/>
   <entry type="NameTag" style="#c6a0f6"/>
-  <entry type="NameVariable" style="#f5a97f"/>
+  <entry type="NameVariable" style="#f4dbd6"/>
+  <entry type="NameVariableClass" style="#f4dbd6"/>
+  <entry type="NameVariableGlobal" style="#f4dbd6"/>
+  <entry type="NameVariableInstance" style="#f4dbd6"/>
+  <entry type="NameVariableMagic" style="#f4dbd6"/>
+  <entry type="NameAttribute" style="#8aadf4"/>
+  <entry type="NameBuiltin" style="#91d7e3"/>
+  <entry type="NameBuiltinPseudo" style="#91d7e3"/>
+  <entry type="NameOther" style="#cad3f5"/>
+  <entry type="Literal" style="#cad3f5"/>
+  <entry type="LiteralDate" style="#cad3f5"/>
   <entry type="LiteralString" style="#a6da95"/>
-  <entry type="LiteralStringDoc" style="#a6da95"/>
-  <entry type="LiteralStringEscape" style="#8aadf4"/>
-  <entry type="LiteralStringInterpol" style="#a6da95"/>
+  <entry type="LiteralStringChar" style="#a6da95"/>
+  <entry type="LiteralStringSingle" style="#a6da95"/>
+  <entry type="LiteralStringDouble" style="#a6da95"/>
+  <entry type="LiteralStringBacktick" style="#a6da95"/>
   <entry type="LiteralStringOther" style="#a6da95"/>
-  <entry type="LiteralStringRegex" style="#8aadf4"/>
   <entry type="LiteralStringSymbol" style="#a6da95"/>
+  <entry type="LiteralStringInterpol" style="#a6da95"/>
+  <entry type="LiteralStringAffix" style="#ed8796"/>
+  <entry type="LiteralStringDelimiter" style="#8aadf4"/>
+  <entry type="LiteralStringEscape" style="#8aadf4"/>
+  <entry type="LiteralStringRegex" style="#8bd5ca"/>
+  <entry type="LiteralStringDoc" style="#6e738d"/>
+  <entry type="LiteralStringHeredoc" style="#6e738d"/>
   <entry type="LiteralNumber" style="#f5a97f"/>
-  <entry type="Operator" style="#91d7e3"/>
+  <entry type="LiteralNumberBin" style="#f5a97f"/>
+  <entry type="LiteralNumberHex" style="#f5a97f"/>
+  <entry type="LiteralNumberInteger" style="#f5a97f"/>
+  <entry type="LiteralNumberFloat" style="#f5a97f"/>
+  <entry type="LiteralNumberIntegerLong" style="#f5a97f"/>
+  <entry type="LiteralNumberOct" style="#f5a97f"/>
+  <entry type="Operator" style="bold #91d7e3"/>
   <entry type="OperatorWord" style="bold #91d7e3"/>
-  <entry type="Punctuation" style="#cad3f5"/>
-  <entry type="Comment" style="italic #5b6078"/>
-  <entry type="CommentPreproc" style="#8aadf4"/>
-  <entry type="GenericDeleted" style="#ee99a0"/>
-  <entry type="GenericEmph" style="italic"/>
-  <entry type="GenericError" style="#ee99a0"/>
-  <entry type="GenericHeading" style="bold #91d7e3"/>
-  <entry type="GenericInserted" style="#a6da95"/>
-  <entry type="GenericOutput" style="#f5a97f"/>
-  <entry type="GenericPrompt" style="bold #6e738d"/>
-  <entry type="GenericStrong" style="bold"/>
-  <entry type="GenericSubheading" style="bold #91d7e3"/>
-  <entry type="GenericTraceback" style="#ee99a0"/>
-  <entry type="TextWhitespace" style="#363a4f"/>
+  <entry type="Comment" style="italic #6e738d"/>
+  <entry type="CommentSingle" style="italic #6e738d"/>
+  <entry type="CommentMultiline" style="italic #6e738d"/>
+  <entry type="CommentSpecial" style="italic #6e738d"/>
+  <entry type="CommentHashbang" style="italic #6e738d"/>
+  <entry type="CommentPreproc" style="italic #6e738d"/>
+  <entry type="CommentPreprocFile" style="bold #6e738d"/>
+  <entry type="Generic" style="#cad3f5"/>
+  <entry type="GenericInserted" style="bg:#363a4f #a6da95"/>
+  <entry type="GenericDeleted" style="#ed8796 bg:#363a4f"/>
+  <entry type="GenericEmph" style="italic #cad3f5"/>
+  <entry type="GenericStrong" style="bold #cad3f5"/>
+  <entry type="GenericUnderline" style="underline #cad3f5"/>
+  <entry type="GenericHeading" style="bold #f5a97f"/>
+  <entry type="GenericSubheading" style="bold #f5a97f"/>
+  <entry type="GenericOutput" style="#cad3f5"/>
+  <entry type="GenericPrompt" style="#cad3f5"/>
+  <entry type="GenericError" style="#ed8796"/>
+  <entry type="GenericTraceback" style="#ed8796"/>
 </style>

--- a/styles/catppuccin-mocha.xml
+++ b/styles/catppuccin-mocha.xml
@@ -1,46 +1,83 @@
 <style name="catppuccin-mocha">
+  <entry type="Background" style="bg:#1e1e2e #cdd6f4"/>
+  <entry type="CodeLine" style="#cdd6f4"/>
   <entry type="Error" style="#f38ba8"/>
-  <entry type="Background" style="#fab387 bg:#1e1e2e"/>
+  <entry type="Other" style="#cdd6f4"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="#45475a"/>
+  <entry type="LineNumbersTable" style="#7f849c"/>
+  <entry type="LineNumbers" style="#7f849c"/>
   <entry type="Keyword" style="#cba6f7"/>
-  <entry type="KeywordConstant" style="italic #cba6f7"/>
-  <entry type="KeywordPseudo" style="bold #cba6f7"/>
-  <entry type="KeywordType" style="#f9e2af"/>
-  <entry type="Name" style="#b4befe"/>
-  <entry type="NameAttribute" style="#f9e2af"/>
-  <entry type="NameBuiltin" style="italic #fab387"/>
+  <entry type="KeywordReserved" style="#cba6f7"/>
+  <entry type="KeywordPseudo" style="#cba6f7"/>
+  <entry type="KeywordConstant" style="#fab387"/>
+  <entry type="KeywordDeclaration" style="#f38ba8"/>
+  <entry type="KeywordNamespace" style="#94e2d5"/>
+  <entry type="KeywordType" style="#f38ba8"/>
+  <entry type="Name" style="#cdd6f4"/>
   <entry type="NameClass" style="#f9e2af"/>
   <entry type="NameConstant" style="#f9e2af"/>
-  <entry type="NameDecorator" style="#f5c2e7"/>
-  <entry type="NameEntity" style="#f5c2e7"/>
-  <entry type="NameException" style="#eba0ac"/>
-  <entry type="NameFunction" style="#89dceb"/>
-  <entry type="NameLabel" style="#f9e2af"/>
-  <entry type="NameNamespace" style="#f9e2af"/>
-  <entry type="NameOther" style="#fab387"/>
+  <entry type="NameDecorator" style="bold #89b4fa"/>
+  <entry type="NameEntity" style="#94e2d5"/>
+  <entry type="NameException" style="#fab387"/>
+  <entry type="NameFunction" style="#89b4fa"/>
+  <entry type="NameFunctionMagic" style="#89b4fa"/>
+  <entry type="NameLabel" style="#89dceb"/>
+  <entry type="NameNamespace" style="#fab387"/>
+  <entry type="NameProperty" style="#fab387"/>
   <entry type="NameTag" style="#cba6f7"/>
-  <entry type="NameVariable" style="#fab387"/>
+  <entry type="NameVariable" style="#f5e0dc"/>
+  <entry type="NameVariableClass" style="#f5e0dc"/>
+  <entry type="NameVariableGlobal" style="#f5e0dc"/>
+  <entry type="NameVariableInstance" style="#f5e0dc"/>
+  <entry type="NameVariableMagic" style="#f5e0dc"/>
+  <entry type="NameAttribute" style="#89b4fa"/>
+  <entry type="NameBuiltin" style="#89dceb"/>
+  <entry type="NameBuiltinPseudo" style="#89dceb"/>
+  <entry type="NameOther" style="#cdd6f4"/>
+  <entry type="Literal" style="#cdd6f4"/>
+  <entry type="LiteralDate" style="#cdd6f4"/>
   <entry type="LiteralString" style="#a6e3a1"/>
-  <entry type="LiteralStringDoc" style="#a6e3a1"/>
-  <entry type="LiteralStringEscape" style="#89b4fa"/>
-  <entry type="LiteralStringInterpol" style="#a6e3a1"/>
+  <entry type="LiteralStringChar" style="#a6e3a1"/>
+  <entry type="LiteralStringSingle" style="#a6e3a1"/>
+  <entry type="LiteralStringDouble" style="#a6e3a1"/>
+  <entry type="LiteralStringBacktick" style="#a6e3a1"/>
   <entry type="LiteralStringOther" style="#a6e3a1"/>
-  <entry type="LiteralStringRegex" style="#89b4fa"/>
   <entry type="LiteralStringSymbol" style="#a6e3a1"/>
+  <entry type="LiteralStringInterpol" style="#a6e3a1"/>
+  <entry type="LiteralStringAffix" style="#f38ba8"/>
+  <entry type="LiteralStringDelimiter" style="#89b4fa"/>
+  <entry type="LiteralStringEscape" style="#89b4fa"/>
+  <entry type="LiteralStringRegex" style="#94e2d5"/>
+  <entry type="LiteralStringDoc" style="#6c7086"/>
+  <entry type="LiteralStringHeredoc" style="#6c7086"/>
   <entry type="LiteralNumber" style="#fab387"/>
-  <entry type="Operator" style="#89dceb"/>
+  <entry type="LiteralNumberBin" style="#fab387"/>
+  <entry type="LiteralNumberHex" style="#fab387"/>
+  <entry type="LiteralNumberInteger" style="#fab387"/>
+  <entry type="LiteralNumberFloat" style="#fab387"/>
+  <entry type="LiteralNumberIntegerLong" style="#fab387"/>
+  <entry type="LiteralNumberOct" style="#fab387"/>
+  <entry type="Operator" style="bold #89dceb"/>
   <entry type="OperatorWord" style="bold #89dceb"/>
-  <entry type="Punctuation" style="#cdd6f4"/>
-  <entry type="Comment" style="italic #585b70"/>
-  <entry type="CommentPreproc" style="#89b4fa"/>
-  <entry type="GenericDeleted" style="#eba0ac"/>
-  <entry type="GenericEmph" style="italic"/>
-  <entry type="GenericError" style="#eba0ac"/>
-  <entry type="GenericHeading" style="bold #89dceb"/>
-  <entry type="GenericInserted" style="#a6e3a1"/>
-  <entry type="GenericOutput" style="#fab387"/>
-  <entry type="GenericPrompt" style="bold #6c7086"/>
-  <entry type="GenericStrong" style="bold"/>
-  <entry type="GenericSubheading" style="bold #89dceb"/>
-  <entry type="GenericTraceback" style="#eba0ac"/>
-  <entry type="TextWhitespace" style="#313244"/>
+  <entry type="Comment" style="italic #6c7086"/>
+  <entry type="CommentSingle" style="italic #6c7086"/>
+  <entry type="CommentMultiline" style="italic #6c7086"/>
+  <entry type="CommentSpecial" style="italic #6c7086"/>
+  <entry type="CommentHashbang" style="italic #6c7086"/>
+  <entry type="CommentPreproc" style="italic #6c7086"/>
+  <entry type="CommentPreprocFile" style="bold #6c7086"/>
+  <entry type="Generic" style="#cdd6f4"/>
+  <entry type="GenericInserted" style="bg:#313244 #a6e3a1"/>
+  <entry type="GenericDeleted" style="#f38ba8 bg:#313244"/>
+  <entry type="GenericEmph" style="italic #cdd6f4"/>
+  <entry type="GenericStrong" style="bold #cdd6f4"/>
+  <entry type="GenericUnderline" style="underline #cdd6f4"/>
+  <entry type="GenericHeading" style="bold #fab387"/>
+  <entry type="GenericSubheading" style="bold #fab387"/>
+  <entry type="GenericOutput" style="#cdd6f4"/>
+  <entry type="GenericPrompt" style="#cdd6f4"/>
+  <entry type="GenericError" style="#f38ba8"/>
+  <entry type="GenericTraceback" style="#f38ba8"/>
 </style>


### PR DESCRIPTION
These definitions have been dynamically created using a script to keep up with changes in the color pallete. [Here's](https://github.com/icy-comet/catppuccin-chroma-theme/) the repository holding the code. I might get this merged in the catppuccin org.

Definition Reference:
- [Catppuccin VS Code](https://github.com/catppuccin/vscode/)
- Pygments version in the [Catppuccin's official repo](https://github.com/catppuccin/python/blob/main/catppuccin/extras/pygments.py).

Attaching some screenshots below for reference. Feel free to open a issue/PR for improvements.

### Mocha
![mocha](https://github.com/alecthomas/chroma/assets/50461557/9e44fab8-1f96-478a-ad7f-1732a54727ab)

### Macchiato
![macchiato](https://github.com/alecthomas/chroma/assets/50461557/74ab9185-cfc5-4a90-806e-8c17239ccdb4)

### Frappe
![frappe](https://github.com/alecthomas/chroma/assets/50461557/512fbbfd-b261-4688-ad04-2f151af71c5a)

### Latte
![latte](https://github.com/alecthomas/chroma/assets/50461557/d024439b-8a5d-4676-8597-8ff877bc8dd4)
