### PR TITLE
Prevent panic from hax lexer

### DIFF
--- a/lexers/haxe.go
+++ b/lexers/haxe.go
@@ -630,7 +630,9 @@ func haxePreProcMutator(state *LexerState) error {
 			state.Stack = stack[len(stack)-1]
 		}
 	case "end":
-		stack = stack[:len(stack)-1]
+		if len(stack) > 0 {
+			stack = stack[:len(stack)-1]
+		}
 	}
 
 	if proc == "if" || proc == "elseif" {


### PR DESCRIPTION
Prevents `runtime error: slice bounds out of range` when list is empty.