### PR TITLE
Add .tpp as a c++ lexer file extension

### DIFF
--- a/lexers/cpp.go
+++ b/lexers/cpp.go
@@ -18,7 +18,7 @@ var CPP = Register(MustNewXMLLexer(
 	&Config{
 		Name:      "C++",
 		Aliases:   []string{"cpp", "c++"},
-		Filenames: []string{"*.cpp", "*.hpp", "*.c++", "*.h++", "*.cc", "*.hh", "*.cxx", "*.hxx", "*.C", "*.H", "*.cp", "*.CPP", "*.cppm", "*.ixx"},
+		Filenames: []string{"*.cpp", "*.hpp", "*.c++", "*.h++", "*.cc", "*.hh", "*.cxx", "*.hxx", "*.C", "*.H", "*.cp", "*.CPP", "*.cppm", "*.ixx", "*.tpp"},
 		MimeTypes: []string{"text/x-c++hdr", "text/x-c++src"},
 		Priority:  0.1,
 		EnsureNL:  true,


### PR DESCRIPTION
This PR adds missing `.tpp` file extension to C++ lexer.