### PR TITLE
Add .eex as a Elixir lexer file extension

### DIFF
--- a/lexers/embedded/elixir.xml
+++ b/lexers/embedded/elixir.xml
@@ -5,6 +5,7 @@
     <alias>ex</alias>
     <alias>exs</alias>
     <filename>*.ex</filename>
+    <filename>*.eex</filename>
     <filename>*.exs</filename>
     <mime_type>text/x-elixir</mime_type>
   </config>


### PR DESCRIPTION
This PR adds missing `.eex` Elixir file extension.