### PR TITLE
Add Pipfile and poetry.lock as a TOML lexer file extension

### DIFF
--- a/lexers/embedded/toml.xml
+++ b/lexers/embedded/toml.xml
@@ -3,6 +3,8 @@
     <name>TOML</name>
     <alias>toml</alias>
     <filename>*.toml</filename>
+    <filename>Pipfile</filename>
+    <filename>poetry.lock</filename>
     <mime_type>text/x-toml</mime_type>
   </config>
   <rules>


### PR DESCRIPTION
This PR adds missing `Pipfile` and `poetry.lock` TOML file extension.