### PR TITLE
Fix ISCdhcpd filename

### DIFF
--- a/lexers/embedded/iscdhcpd.xml
+++ b/lexers/embedded/iscdhcpd.xml
@@ -2,7 +2,7 @@
   <config>
     <name>ISCdhcpd</name>
     <alias>iscdhcpd</alias>
-    <filename>*.conf</filename>
+    <filename>dhcpd.conf</filename>
   </config>
   <rules>
     <state name="interpol">


### PR DESCRIPTION
This PR solves the conflict between ApacheConf lexer and ISCdhcpd lexer where ISCdhcpd uses `*.conf` as filename which overloads ApacheConf that defines only `apache.conf`. To be error prune and less noisy I changed to `dhcpd.conf` as per the [docs](https://kb.isc.org/docs/isc-dhcp-41-manual-pages-dhcpdconf) say.