### PR TITLE
Update clojure.xml to target EDN

### DIFF
--- a/lexers/embedded/clojure.xml
+++ b/lexers/embedded/clojure.xml
@@ -3,9 +3,12 @@
     <name>Clojure</name>
     <alias>clojure</alias>
     <alias>clj</alias>
+    <alias>edn</alias>
     <filename>*.clj</filename>
+    <filename>*.edn</filename>
     <mime_type>text/x-clojure</mime_type>
     <mime_type>application/x-clojure</mime_type>
+    <mime_type>application/edn</mime_type>
   </config>
   <rules>
     <state name="root">


### PR DESCRIPTION
These changes allow EDN files, together with the commonly used `application/edn` MIME type, to be highlighted as Clojure syntax.

Fixes #824