### PR TITLE
Add ActionScript 3 content analyser

### DIFF
--- a/lexers/actionscript3.go
+++ b/lexers/actionscript3.go
@@ -1,0 +1,29 @@
+package lexers
+
+import (
+	"regexp"
+
+	. "github.com/alecthomas/chroma/v2" // nolint
+)
+
+var actionscript3AnalyserRe = regexp.MustCompile(`\w+\s*:\s*\w`)
+
+// Actionscript 3 lexer.
+var Actionscript3 = Register(MustNewXMLLexer(
+	embedded,
+	"embedded/actionscript_3.xml",
+).SetConfig(
+	&Config{
+		Name:      "ActionScript 3",
+		Aliases:   []string{"as3", "actionscript3"},
+		Filenames: []string{"*.as"},
+		MimeTypes: []string{"application/x-actionscript3", "text/x-actionscript3", "text/actionscript3"},
+		DotAll:    true,
+	},
+).SetAnalyser(func(text string) float32 {
+	if actionscript3AnalyserRe.MatchString(text) {
+		return 0.3
+	}
+
+	return 0
+}))

--- a/lexers/actionscript3_test.go
+++ b/lexers/actionscript3_test.go
@@ -10,22 +10,22 @@ import (
 	"github.com/alecthomas/assert/v2"
 )
 
-func TestC_AnalyseText(t *testing.T) {
+func TestActionscript3_AnalyseText(t *testing.T) {
 	tests := map[string]struct {
 		Filepath string
 		Expected float32
 	}{
-		"include": {
-			Filepath: "testdata/c_include.c",
-			Expected: 0.1,
+		"basic": {
+			Filepath: "testdata/actionscript3.as",
+			Expected: 0.3,
 		},
-		"ifdef": {
-			Filepath: "testdata/c_ifdef.c",
-			Expected: 0.1,
+		"capital letters": {
+			Filepath: "testdata/actionscript3_capital_letter.as",
+			Expected: 0.3,
 		},
-		"ifndef": {
-			Filepath: "testdata/c_ifndef.c",
-			Expected: 0.1,
+		"spaces": {
+			Filepath: "testdata/actionscript3_spaces.as",
+			Expected: 0.3,
 		},
 	}
 
@@ -35,7 +35,7 @@ func TestC_AnalyseText(t *testing.T) {
 			data, err := os.ReadFile(test.Filepath)
 			assert.NoError(t, err)
 
-			analyser, ok := lexers.C.(chroma.Analyser)
+			analyser, ok := lexers.Actionscript3.(chroma.Analyser)
 			assert.True(t, ok)
 
 			assert.Equal(t, test.Expected, analyser.AnalyseText(string(data)))

--- a/lexers/testdata/actionscript3.as
+++ b/lexers/testdata/actionscript3.as
@@ -1,0 +1,1 @@
+var circle:Sprite = new Sprite();

--- a/lexers/testdata/actionscript3_capital_letter.as
+++ b/lexers/testdata/actionscript3_capital_letter.as
@@ -1,0 +1,1 @@
+var CIRCLE:Sprite = new Sprite();

--- a/lexers/testdata/actionscript3_spaces.as
+++ b/lexers/testdata/actionscript3_spaces.as
@@ -1,0 +1,1 @@
+var circle: Sprite = new Sprite();


### PR DESCRIPTION
This PR adds content analyser for Action Script 3 as implemented in [Pygments](https://github.com/pygments/pygments/blob/master/pygments/lexers/actionscript.py#L198).