### PR TITLE
Add missing *.twig file extension

### DIFF
--- a/lexers/embedded/twig.xml
+++ b/lexers/embedded/twig.xml
@@ -2,6 +2,7 @@
   <config>
     <name>Twig</name>
     <alias>twig</alias>
+    <filename>*.twig</filename>
     <mime_type>application/x-twig</mime_type>
     <dot_all>true</dot_all>
   </config>


### PR DESCRIPTION
This PR adds missing `*.twig` file extension to Twig lexer.