### PR TITLE
Set priority for INI lexer over Inform 6

### DIFF
--- a/lexers/embedded/ini.xml
+++ b/lexers/embedded/ini.xml
@@ -15,6 +15,7 @@
     <filename>.pylintrc</filename>
     <mime_type>text/x-ini</mime_type>
     <mime_type>text/inf</mime_type>
+    <priority>0.1</priority> <!-- higher priority than Inform 6 -->
   </config>
   <rules>
     <state name="root">


### PR DESCRIPTION
The file extension `.inf` is far more common as `INI` than `Inform 6` since both share the same file extension.

https://en.wikipedia.org/wiki/INF_file
https://www.ifwiki.org/Inform_6