### PR TITLE
Set priority for GAS lexer

### DIFF
--- a/lexers/embedded/gas.xml
+++ b/lexers/embedded/gas.xml
@@ -6,6 +6,7 @@
     <filename>*.s</filename>
     <filename>*.S</filename>
     <mime_type>text/x-gas</mime_type>
+    <priority>0.1</priority>
   </config>
   <rules>
     <state name="punctuation">


### PR DESCRIPTION
This PR sets priority for `GAS` lexer over `ca 65 assembler` and `ArmAsm`.