### PR TITLE
Set priority for NASM lexer

### DIFF
--- a/lexers/embedded/nasm.xml
+++ b/lexers/embedded/nasm.xml
@@ -4,8 +4,10 @@
     <alias>nasm</alias>
     <filename>*.asm</filename>
     <filename>*.ASM</filename>
+    <filename>*.nasm</filename>
     <mime_type>text/x-nasm</mime_type>
     <case_insensitive>true</case_insensitive>
+    <priority>1.0</priority> <!-- TASM uses the same file endings, but TASM is not as common as NASM, so we prioritize NASM higher by default. -->
   </config>
   <rules>
     <state name="punctuation">


### PR DESCRIPTION
This PR sets priority for `NASM` over `TASM` as implemented in [Pygments](https://github.com/pygments/pygments/blob/1a48184b8bf373c7037d5cc3a7f0eef51c093140/pygments/lexers/asm.py#L721). It also adds `*.nasm` as a file extension supported in this lexer.