### PR TITLE
Fix GDScript3 analyse regexes

### DIFF
--- a/lexers/embedded/gdscript.xml
+++ b/lexers/embedded/gdscript.xml
@@ -7,8 +7,8 @@
     <mime_type>text/x-gdscript</mime_type>
     <mime_type>application/x-gdscript</mime_type>
     <priority>0.1</priority>
-    <analyse first="true">
-      <regex pattern="^@" score="0.4"/>
+    <analyse>
+      <regex pattern="^export" score="0.1"/>
     </analyse>
   </config>
   <rules>

--- a/lexers/embedded/gdscript3.xml
+++ b/lexers/embedded/gdscript3.xml
@@ -6,8 +6,10 @@
     <filename>*.gd</filename>
     <mime_type>text/x-gdscript</mime_type>
     <mime_type>application/x-gdscript</mime_type>
-    <analyse first="true">
-      <regex pattern="^export" score="0.1"/>
+    <analyse>
+      <regex pattern="func (_ready|_init|_input|_process|_unhandled_input)" score="0.8"/>
+      <regex pattern="(extends |class_name |onready |preload|load|setget|func [^_])" score="0.4"/>
+      <regex pattern="(var|const|enum|export|signal|tool)" score="0.2"/>
     </analyse>
   </config>
   <rules>


### PR DESCRIPTION
2 weeks ago `GDScript` was renamed to `GDScript3` adding support for v4 and added analyse regexes but it's wrong according to [Pygments](https://github.com/pygments/pygments/blob/1a48184b8bf373c7037d5cc3a7f0eef51c093140/pygments/lexers/gdscript.py#L171).



