### PR TITLE
lexers: support for nim GENERALIZED_TRIPLESTR_LIT

### DIFF
--- a/lexers/embedded/nim.xml
+++ b/lexers/embedded/nim.xml
@@ -132,6 +132,10 @@
       <rule pattern="\.\.|\.|,|\[\.|\.\]|\{\.|\.\}|\(\.|\.\)|\{|\}|\(|\)|:|\^|`|;">
         <token type="Punctuation"/>
       </rule>
+      <rule pattern="(?:[\w]+)&#34;&#34;&#34;">
+        <token type="LiteralString"/>
+        <push state="tdqs"/>
+      </rule>
       <rule pattern="(?:[\w]+)&#34;">
         <token type="LiteralString"/>
         <push state="rdqs"/>


### PR DESCRIPTION
Adds support for [generalized raw string literals](https://nim-lang.org/docs/manual.html#lexical-analysis-generalized-raw-string-literals) in Nim with triple-quotes.

Not familiar with how to write these, but I thought I'd give it a shot and this seems to work.