### PR TITLE
Add `*.Dockerfile` to docker lexer

### DIFF
--- a/lexers/embedded/docker.xml
+++ b/lexers/embedded/docker.xml
@@ -6,6 +6,7 @@
     <filename>Dockerfile</filename>
     <filename>Dockerfile.*</filename>
     <filename>*.docker</filename>
+    <filename>*.Dockerfile</filename>
     <mime_type>text/x-dockerfile-config</mime_type>
     <case_insensitive>true</case_insensitive>
   </config>

--- a/lexers/embedded/docker.xml
+++ b/lexers/embedded/docker.xml
@@ -5,8 +5,8 @@
     <alias>dockerfile</alias>
     <filename>Dockerfile</filename>
     <filename>Dockerfile.*</filename>
-    <filename>*.docker</filename>
     <filename>*.Dockerfile</filename>
+    <filename>*.docker</filename>
     <mime_type>text/x-dockerfile-config</mime_type>
     <case_insensitive>true</case_insensitive>
   </config>


### PR DESCRIPTION
Add another filename variant. Seen in the wild [here](https://github.com/goauthentik/authentik/blob/main/radius.Dockerfile).