### PR TITLE
Make `tty_indexed.go` respond to `None` like `tty_truecolour.go`

### DIFF
--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -242,12 +242,21 @@ func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma
 	theme := styleToEscapeSequence(c.table, style)
 	for token := it(); token != chroma.EOF; token = it() {
 		clr, ok := theme[token.Type]
+
+		// This search mimics how styles.Get() is used in tty_truecolour.go.
 		if !ok {
 			clr, ok = theme[token.Type.SubCategory()]
 			if !ok {
-				clr = theme[token.Type.Category()]
+				clr, ok = theme[token.Type.Category()]
+				if !ok {
+					clr, ok = theme[chroma.Text]
+					if !ok {
+						clr = theme[chroma.Background]
+					}
+				}
 			}
 		}
+
 		if clr != "" {
 			fmt.Fprint(w, clr)
 		}

--- a/formatters/tty_indexed_test.go
+++ b/formatters/tty_indexed_test.go
@@ -1,13 +1,34 @@
 package formatters
 
 import (
+	"strings"
 	"testing"
 
 	assert "github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/styles"
 )
 
 func TestClosestColour(t *testing.T) {
 	actual := findClosest(ttyTables[256], chroma.MustParseColour("#e06c75"))
 	assert.Equal(t, chroma.MustParseColour("#d75f87"), actual)
+}
+
+func TestNoneColour(t *testing.T) {
+	style := styles.Registry["gruvbox"]
+	formatter := TTY256
+	tokenType := chroma.None
+
+	stringBuilder := strings.Builder{}
+	err := formatter.Format(&stringBuilder, style, chroma.Literator(chroma.Token{
+		Type:  tokenType,
+		Value: "WORD",
+	}))
+	assert.NoError(t, err)
+
+	// "187" = #d7d7af approximates #ebdbb2, which is the Gruvbox foreground
+	// color of the "Background" type, see gruvbox.xml in this repo.
+	//
+	// 187 color ref: https://jonasjacek.github.io/colors/
+	assert.Equal(t, "\033[38;5;187mWORD\033[0m", stringBuilder.String())
 }

--- a/formatters/tty_indexed_test.go
+++ b/formatters/tty_indexed_test.go
@@ -6,7 +6,6 @@ import (
 
 	assert "github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/chroma/v2"
-	"github.com/alecthomas/chroma/v2/styles"
 )
 
 func TestClosestColour(t *testing.T) {
@@ -15,20 +14,23 @@ func TestClosestColour(t *testing.T) {
 }
 
 func TestNoneColour(t *testing.T) {
-	style := styles.Registry["gruvbox"]
 	formatter := TTY256
 	tokenType := chroma.None
 
+	style, err := chroma.NewStyle("test", chroma.StyleEntries{
+		chroma.Background: "#D0ab1e",
+	})
+	assert.NoError(t, err)
+
 	stringBuilder := strings.Builder{}
-	err := formatter.Format(&stringBuilder, style, chroma.Literator(chroma.Token{
+	err = formatter.Format(&stringBuilder, style, chroma.Literator(chroma.Token{
 		Type:  tokenType,
 		Value: "WORD",
 	}))
 	assert.NoError(t, err)
 
-	// "187" = #d7d7af approximates #ebdbb2, which is the Gruvbox foreground
-	// color of the "Background" type, see gruvbox.xml in this repo.
+	// "178" = #d7af00 approximates #d0ab1e
 	//
-	// 187 color ref: https://jonasjacek.github.io/colors/
-	assert.Equal(t, "\033[38;5;187mWORD\033[0m", stringBuilder.String())
+	// 178 color ref: https://jonasjacek.github.io/colors/
+	assert.Equal(t, "\033[38;5;178mWORD\033[0m", stringBuilder.String())
 }


### PR DESCRIPTION
Before this change, asking `tty_indexed.go` for the `None` type ("No highlighting") returned an empty string.

With this change in place, asking `tty_indexed.go` for the `None` type returns (the closest it can get to) the same colour as `tty_truecolor.go`.

Relates to https://github.com/walles/moar/issues/161#issuecomment-1758393935.