### PR TITLE
Add file extensions to go_template lexer

### DIFF
--- a/lexers/embedded/go_template.xml
+++ b/lexers/embedded/go_template.xml
@@ -2,6 +2,8 @@
   <config>
     <name>Go Template</name>
     <alias>go-template</alias>
+    <filename>*.gotmpl</filename>
+    <filename>*.go.tmpl</filename>
   </config>
   <rules>
     <state name="template">


### PR DESCRIPTION
According to [this](https://stackoverflow.com/questions/22254013), these two are the most popular.

There is also `.gohtml` and `.go.html` but it would need [multi-language highlighting](https://github.com/alecthomas/chroma/issues/783). Also, `.tmpl` is common, but it's already in-use by the cheetah lexer unfortunately.

EOL change is in conformance to [editorconfig](https://github.com/alecthomas/chroma/blob/b127e3569cecb6023e71df532c6d9f371d945914/.editorconfig#L13).