### PR TITLE
fix(dns): highlight domain names as NameClass

### DIFF
--- a/lexers/embedded/dns.xml
+++ b/lexers/embedded/dns.xml
@@ -27,7 +27,7 @@
       <rule pattern="\b([\w\d.-])+\.($|\s)">
         <token type="NameProperty"/>
       </rule>
-      <rule pattern="^(@|[\w\d-]+)">
+      <rule pattern="([\w\d\.-]+\.[a-z-]{2,24}\.?|^(@|[\w\d-]+))">
         <token type="NameClass"/>
       </rule>
       <rule pattern="^\$(TTL|GENERATE|INCLUDE|ORIGIN)">


### PR DESCRIPTION
This commit fixes #885.
Before this commit, only the first part (before the first dot) of a domain name was highlighted as NameClass``, which made the rest highlight in `err` (red). This commit makes domain names anywhere in the line highlight as NameClass, still allowing @ at the start of a line to be highlighted just as before.