### PR TITLE
styles(catpuccin/gh-dark): LineHighlight grp

### DIFF
--- a/styles/catppuccin-frappe.xml
+++ b/styles/catppuccin-frappe.xml
@@ -5,7 +5,7 @@
   <entry type="Other" style="#c6d0f5"/>
   <entry type="LineTableTD" style=""/>
   <entry type="LineTable" style=""/>
-  <entry type="LineHighlight" style="#51576d"/>
+  <entry type="LineHighlight" style="bg:#51576d"/>
   <entry type="LineNumbersTable" style="#838ba7"/>
   <entry type="LineNumbers" style="#838ba7"/>
   <entry type="Keyword" style="#ca9ee6"/>

--- a/styles/catppuccin-latte.xml
+++ b/styles/catppuccin-latte.xml
@@ -5,7 +5,7 @@
   <entry type="Other" style="#4c4f69"/>
   <entry type="LineTableTD" style=""/>
   <entry type="LineTable" style=""/>
-  <entry type="LineHighlight" style="#bcc0cc"/>
+  <entry type="LineHighlight" style="bg:#bcc0cc"/>
   <entry type="LineNumbersTable" style="#8c8fa1"/>
   <entry type="LineNumbers" style="#8c8fa1"/>
   <entry type="Keyword" style="#8839ef"/>

--- a/styles/catppuccin-macchiato.xml
+++ b/styles/catppuccin-macchiato.xml
@@ -5,7 +5,7 @@
   <entry type="Other" style="#cad3f5"/>
   <entry type="LineTableTD" style=""/>
   <entry type="LineTable" style=""/>
-  <entry type="LineHighlight" style="#494d64"/>
+  <entry type="LineHighlight" style="bg:#494d64"/>
   <entry type="LineNumbersTable" style="#8087a2"/>
   <entry type="LineNumbers" style="#8087a2"/>
   <entry type="Keyword" style="#c6a0f6"/>

--- a/styles/catppuccin-mocha.xml
+++ b/styles/catppuccin-mocha.xml
@@ -5,7 +5,7 @@
   <entry type="Other" style="#cdd6f4"/>
   <entry type="LineTableTD" style=""/>
   <entry type="LineTable" style=""/>
-  <entry type="LineHighlight" style="#45475a"/>
+  <entry type="LineHighlight" style="bg:#45475a"/>
   <entry type="LineNumbersTable" style="#7f849c"/>
   <entry type="LineNumbers" style="#7f849c"/>
   <entry type="Keyword" style="#cba6f7"/>

--- a/styles/github-dark.xml
+++ b/styles/github-dark.xml
@@ -1,6 +1,6 @@
 <style name="github-dark">
   <entry type="Error" style="#f85149"/>
-  <entry type="LineHighlight" style="#6e7681"/>
+  <entry type="LineHighlight" style="bg:#6e7681"/>
   <entry type="LineNumbers" style="#6e7681"/>
   <entry type="Background" style="#e6edf3 bg:#0d1117"/>
   <entry type="Keyword" style="#ff7b72"/>


### PR DESCRIPTION
should address #910.

let me know if any color definition seems odd.

PS: also updated the auto-gen template [here](https://github.com/icy-comet/catppuccin-chroma-theme)