### PR TITLE
Fix type operators not being recognised in Haskell

### DIFF
--- a/lexers/embedded/haskell.xml
+++ b/lexers/embedded/haskell.xml
@@ -86,7 +86,7 @@
       <rule pattern="\\(?![:!#$%&amp;*+.\\/&lt;=&gt;?@^|~-]+)">
         <token type="NameFunction"/>
       </rule>
-      <rule pattern="(&lt;-|::|-&gt;|=&gt;|=)(?![:!#$%&amp;*+.\\/&lt;=&gt;?@^|~-]+)">
+      <rule pattern="(&lt;-|::|-&gt;|=&gt;|=|'([:!#$%&amp;*+.\\/&lt;=&gt;?@^|~-]+))(?![:!#$%&amp;*+.\\/&lt;=&gt;?@^|~-]+)">
         <token type="OperatorWord"/>
       </rule>
       <rule pattern=":[:!#$%&amp;*+.\\/&lt;=&gt;?@^|~-]*">


### PR DESCRIPTION
As was pointed out in https://github.com/alecthomas/chroma/issues/793, the Haskell lexer does not handle type operators correctly. This patch fixes this, by explicitly allowing operators prefixed with `'`. 

----
### Before

<img width="318" alt="Screenshot 2024-01-08 at 23 17 04" src="https://github.com/alecthomas/chroma/assets/15182576/17e3ed77-0d9c-45eb-bd2b-ffcfaa4bb9ce">


<img width="804" alt="Screenshot 2024-01-08 at 23 04 44" src="https://github.com/alecthomas/chroma/assets/15182576/7ad94f68-a8f6-4338-ba71-26e91c69a0fe">


### After
<img width="309" alt="Screenshot 2024-01-08 at 23 17 23" src="https://github.com/alecthomas/chroma/assets/15182576/314ebc1e-c896-430d-b539-04655feb0b69">


<img width="803" alt="Screenshot 2024-01-08 at 23 06 48" src="https://github.com/alecthomas/chroma/assets/15182576/ebfde1ae-5b5d-44d9-881c-928e492cf3cc">



