### PR TITLE
Add .avsc to JSON lexer

### DIFF
--- a/lexers/embedded/json.xml
+++ b/lexers/embedded/json.xml
@@ -3,6 +3,7 @@
     <name>JSON</name>
     <alias>json</alias>
     <filename>*.json</filename>
+    <filename>*.avsc</filename>
     <mime_type>application/json</mime_type>
     <dot_all>true</dot_all>
     <not_multiline>true</not_multiline>


### PR DESCRIPTION
`.avsc` files are pure JSON.

References:

- https://avro.apache.org/docs/1.11.1/getting-started-java/#defining-a-schema
- https://github.com/github-linguist/linguist/blob/559a6426942abcae16b6d6b328147476432bf6cb/lib/linguist/languages.yml#L3148