### PR TITLE
Provide faster version of Formatter.Format that allows for skipping expensive recalculations of CSS

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -214,19 +214,19 @@ func (h highlightRanges) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
 func (h highlightRanges) Less(i, j int) bool { return h[i][0] < h[j][0] }
 
 func (f *Formatter) Format(w io.Writer, style *chroma.Style, iterator chroma.Iterator) (err error) {
-	return f.writeHTML(w, style, iterator.Tokens())
+	return f.writeHTML(w, style, f.StyleToCSS(style), iterator.Tokens())
+}
+
+// FastFormat is the same as Format, but the caller must precompute and provide the CSS map computed by Formatter.StyleToCSS(style).
+// This avoids expensive reconstruction of the CSS map on repeat calls.
+func (f *Formatter) FastFormat(w io.Writer, style *chroma.Style, css map[chroma.TokenType]string, iterator chroma.Iterator) (err error) {
+	return f.writeHTML(w, style, css, iterator.Tokens())
 }
 
 // We deliberately don't use html/template here because it is two orders of magnitude slower (benchmarked).
 //
 // OTOH we need to be super careful about correct escaping...
-func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.Token) (err error) { // nolint: gocyclo
-	css := f.styleToCSS(style)
-	if !f.Classes {
-		for t, style := range css {
-			css[t] = compressStyle(style)
-		}
-	}
+func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, css map[chroma.TokenType]string, tokens []chroma.Token) (err error) { // nolint: gocyclo
 	if f.standalone {
 		fmt.Fprint(w, "<html>\n")
 		if f.Classes {
@@ -464,6 +464,17 @@ func (f *Formatter) WriteCSS(w io.Writer, style *chroma.Style) error {
 		}
 	}
 	return nil
+}
+
+// StyleToCSS converts the given chroma Style into a compressed CSS map for re-use by FastFormat.
+func (f *Formatter) StyleToCSS(style *chroma.Style) map[chroma.TokenType]string {
+	css := f.styleToCSS(style) // Does not include compression.
+	if !f.Classes {
+		for t, style := range css {
+			css[t] = compressStyle(style)
+		}
+	}
+	return css
 }
 
 func (f *Formatter) styleToCSS(style *chroma.Style) map[chroma.TokenType]string {


### PR DESCRIPTION
Formatter.Format currently spends most of its time (for small calls) reconstructing and re-compressing a CSS map from the given style, which in most cases will not be changing between calls to Format().

Expose public StyleToCSS() and FastFormat() methods that allow the caller to precompute this CSS map to improve performance.

This PR just proposes the simplest backwards-compatible change to allow the performance gains in question. A redesign of Formatter.Format might be called for, but memoizing the CSS map result may be expensive too if style names can't be assumed to uniquely identify an unmodified style.