### PR TITLE
C#: Allow for empty comments

### DIFF
--- a/lexers/embedded/c#.xml
+++ b/lexers/embedded/c#.xml
@@ -19,10 +19,10 @@
       <rule pattern="\\\n">
         <token type="Text"/>
       </rule>
-      <rule pattern="///[^\n\r]+">
+      <rule pattern="///[^\n\r]*">
         <token type="CommentSpecial"/>
       </rule>
-      <rule pattern="//[^\n\r]+">
+      <rule pattern="//[^\n\r]*">
         <token type="CommentSingle"/>
       </rule>
       <rule pattern="/[*].*?[*]/">

--- a/lexers/testdata/csharp/csharp_comment_single.actual
+++ b/lexers/testdata/csharp/csharp_comment_single.actual
@@ -1,2 +1,3 @@
 // TODO: Maybe later
 // TODO: Implement more features
+//

--- a/lexers/testdata/csharp/csharp_comment_single.expected
+++ b/lexers/testdata/csharp/csharp_comment_single.expected
@@ -1,5 +1,7 @@
 [
   {"type":"CommentSingle","value":"// TODO: Maybe later"},
   {"type":"Text","value":"\n"},
-  {"type":"CommentSingle","value":"// TODO: Implement more features"}
+  {"type":"CommentSingle","value":"// TODO: Implement more features"},
+  {"type":"Text","value":"\n"},
+  {"type":"CommentSingle","value":"//"}
 ]

--- a/lexers/testdata/csharp/csharp_comment_summary.actual
+++ b/lexers/testdata/csharp/csharp_comment_summary.actual
@@ -1,3 +1,4 @@
 /// <summary>
 /// Class <c>Point</c> models a point in a two-dimensional plane.
+///
 /// </summary>

--- a/lexers/testdata/csharp/csharp_comment_summary.expected
+++ b/lexers/testdata/csharp/csharp_comment_summary.expected
@@ -3,5 +3,7 @@
   {"type":"Text","value":"\n"},
   {"type":"CommentSpecial","value":"/// Class \u003cc\u003ePoint\u003c/c\u003e models a point in a two-dimensional plane."},
   {"type":"Text","value":"\n"},
+  {"type":"CommentSpecial","value":"///"},
+  {"type":"Text","value":"\n"},
   {"type":"CommentSpecial","value":"/// \u003c/summary\u003e"}
 ]


### PR DESCRIPTION
Adjust the lexer of C# to properly lex empty comments. Test cases were added.