### PR TITLE
Add Bazel bzlmod support into Python lexer

### DIFF
--- a/lexers/embedded/python.xml
+++ b/lexers/embedded/python.xml
@@ -19,6 +19,10 @@
     <filename>BUILD</filename>
     <filename>BUILD.bazel</filename>
     <filename>WORKSPACE</filename>
+    <filename>WORKSPACE.bzlmod</filename>
+    <filename>WORKSPACE.bazel</filename>
+    <filename>MODULE.bazel</filename>
+    <filename>REPO.bazel</filename>
     <filename>*.tac</filename>
     <mime_type>text/x-python</mime_type>
     <mime_type>application/x-python</mime_type>


### PR DESCRIPTION
https://bazel.build/concepts/build-ref

"such a boundary marker file could be MODULE.bazel, REPO.bazel, or in legacy contexts, WORKSPACE or WORKSPACE.bazel."