### PR TITLE
Org: Keep all newlines

### DIFF
--- a/lexers/embedded/org_mode.xml
+++ b/lexers/embedded/org_mode.xml
@@ -228,42 +228,42 @@
       </rule>
     </state>
     <state name="inline">
-      <rule pattern="(\s)*(\*[^ \n*][^*]+?[^ \n*]\*)((?=\W|\n|$))">
+      <rule pattern="(\s*)(\*[^ \n*][^*]+?[^ \n*]\*)((?=\W|\n|$))">
         <bygroups>
           <token type="Text"/>
           <token type="GenericStrong"/>
           <token type="Text"/>
         </bygroups>
       </rule>
-      <rule pattern="(\s)*(/[^/]+?/)((?=\W|\n|$))">
+      <rule pattern="(\s*)(/[^/]+?/)((?=\W|\n|$))">
         <bygroups>
           <token type="Text"/>
           <token type="GenericEmph"/>
           <token type="Text"/>
         </bygroups>
       </rule>
-      <rule pattern="(\s)*(=[^\n=]+?=)((?=\W|\n|$))">
+      <rule pattern="(\s*)(=[^\n=]+?=)((?=\W|\n|$))">
         <bygroups>
           <token type="Text"/>
           <token type="NameClass"/>
           <token type="Text"/>
         </bygroups>
       </rule>
-      <rule pattern="(\s)*(~[^\n~]+?~)((?=\W|\n|$))">
+      <rule pattern="(\s*)(~[^\n~]+?~)((?=\W|\n|$))">
         <bygroups>
           <token type="Text"/>
           <token type="NameClass"/>
           <token type="Text"/>
         </bygroups>
       </rule>
-      <rule pattern="(\s)*(\+[^+]+?\+)((?=\W|\n|$))">
+      <rule pattern="(\s*)(\+[^+]+?\+)((?=\W|\n|$))">
         <bygroups>
           <token type="Text"/>
           <token type="GenericDeleted"/>
           <token type="Text"/>
         </bygroups>
       </rule>
-      <rule pattern="(\s)*(_[^_]+?_)((?=\W|\n|$))">
+      <rule pattern="(\s*)(_[^_]+?_)((?=\W|\n|$))">
         <bygroups>
           <token type="Text"/>
           <token type="GenericUnderline"/>

--- a/lexers/testdata/org.actual
+++ b/lexers/testdata/org.actual
@@ -143,3 +143,17 @@ manual/Footnotes.html][page for footnotes]].
 # Local Variables:
 # org-link-file-path-type: relative
 # End:
+
+Generic text.
+
+/Italicized/
+
+*strong*
+
+=Heading=
+
+~Codeblock~
+
++StrikeTrough+
+
+_Underlined_

--- a/lexers/testdata/org.expected
+++ b/lexers/testdata/org.expected
@@ -28,7 +28,7 @@
   {"type":"NameClass","value":"=EXPORT_FILE_NAME="},
   {"type":"Text","value":"\nproperty in here. But then you also lose the tag and property\ninheritance Org awesomeness.\n\nline one "},
   {"type":"Operator","value":"\\\\"},
-  {"type":"Text","value":"\nline two\n"},
+  {"type":"Text","value":"\nline two\n\n"},
   {"type":"GenericStrong","value":"*bold*"},
   {"type":"Text","value":" "},
   {"type":"GenericEmph","value":"/italics/"},
@@ -361,5 +361,16 @@
   {"type":"Comment","value":"# org-link-file-path-type: relative"},
   {"type":"Text","value":"\n"},
   {"type":"Comment","value":"# End:"},
-  {"type":"Text","value":"\n"}
+  {"type":"Text","value":"\n\nGeneric text.\n\n"},
+  {"type":"GenericEmph","value":"/Italicized/"},
+  {"type":"Text","value":"\n\n"},
+  {"type":"GenericStrong","value":"*strong*"},
+  {"type":"Text","value":"\n\n"},
+  {"type":"NameClass","value":"=Heading="},
+  {"type":"Text","value":"\n\n"},
+  {"type":"NameClass","value":"~Codeblock~"},
+  {"type":"Text","value":"\n\n"},
+  {"type":"GenericDeleted","value":"+StrikeTrough+"},
+  {"type":"Text","value":"\n\n"},
+  {"type":"GenericUnderline","value":"_Underlined_"}
 ]


### PR DESCRIPTION
- Move the `*` operator to inside the capturing group so all characters that match `\s` is preserved and not just the first character.
- Add tests.
- Resolves https://github.com/alecthomas/chroma/issues/845

<details><summary>Input</summary>

```orgmode
Generic text.

/Italicized/

*strong*

=Heading=

~Codeblock~

+StrikeTrough+

_Underlined_
```

</details>

## Before
![Screen Shot 2024-04-01 at 23 26 15](https://github.com/alecthomas/chroma/assets/25481501/0ddc4b34-c434-4798-9b2a-0773b2be4f05)

## After
![Screen Shot 2024-04-01 at 23 25 52](https://github.com/alecthomas/chroma/assets/25481501/ad46591d-8d3c-421e-8564-d3d36abe6fa1)
