### PR TITLE
Improve startup time

### DIFF
--- a/style.go
+++ b/style.go
@@ -224,7 +224,6 @@ func (s *StyleBuilder) Build() (*Style, error) {
 // StyleEntries mapping TokenType to colour definition.
 type StyleEntries map[TokenType]string
 
-// FIXME: We don't want this signature to be public
 func NewEmbeddedXMLStyle(fs *embed.FS, fileName string) (*Style, error) {
 	// Check that we can read the file
 	r, err := fs.Open(fileName)
@@ -284,8 +283,6 @@ type Style struct {
 }
 
 func (s *Style) entries() map[TokenType]StyleEntry {
-	// FIXME: Does this function need locking?
-
 	if s._entries != nil {
 		return s._entries
 	}

--- a/styles/api.go
+++ b/styles/api.go
@@ -23,16 +23,11 @@ var Registry = func() map[string]*chroma.Style {
 		if file.IsDir() {
 			continue
 		}
-		r, err := embedded.Open(file.Name())
-		if err != nil {
-			panic(err)
-		}
-		style, err := chroma.NewXMLStyle(r)
+		style, err := chroma.NewEmbeddedXMLStyle(&embedded, file.Name())
 		if err != nil {
 			panic(err)
 		}
 		registry[style.Name] = style
-		_ = r.Close()
 	}
 	return registry
 }()


### PR DESCRIPTION
By not loading styles until they are needed.

This takes [moar](https://github.com/walles/moar)'s startup time down from ~25ms to ~18ms on my machine.

One potential downside of this change is that `NewEmbeddedXMLStyle()` is added to the public API.

But since styles are split between `style.go` and `styles/api.go` I was unable to come up with a solution that didn't change the public API.

Also I'm unsure whether the improved startup performance is worth the extra complexity (which isn't bad really, but still). You be the judge of that.