### PR TITLE
chore(styles): add tokyonight inspired styles

### DIFF
--- a/styles/tokyonight-day.xml
+++ b/styles/tokyonight-day.xml
@@ -1,0 +1,83 @@
+<style name="tokyonight-day">
+  <entry type="Background" style="bg:#e1e2e7 #3760bf"/>
+  <entry type="CodeLine" style="#3760bf"/>
+  <entry type="Error" style="#c64343"/>
+  <entry type="Other" style="#3760bf"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#a1a6c5"/>
+  <entry type="LineNumbersTable" style="#6172b0"/>
+  <entry type="LineNumbers" style="#6172b0"/>
+  <entry type="Keyword" style="#9854f1"/>
+  <entry type="KeywordReserved" style="#9854f1"/>
+  <entry type="KeywordPseudo" style="#9854f1"/>
+  <entry type="KeywordConstant" style="#8c6c3e"/>
+  <entry type="KeywordDeclaration" style="#9d7cd8"/>
+  <entry type="KeywordNamespace" style="#007197"/>
+  <entry type="KeywordType" style="#0db9d7"/>
+  <entry type="Name" style="#3760bf"/>
+  <entry type="NameClass" style="#b15c00"/>
+  <entry type="NameConstant" style="#b15c00"/>
+  <entry type="NameDecorator" style="bold #2e7de9"/>
+  <entry type="NameEntity" style="#007197"/>
+  <entry type="NameException" style="#8c6c3e"/>
+  <entry type="NameFunction" style="#2e7de9"/>
+  <entry type="NameFunctionMagic" style="#2e7de9"/>
+  <entry type="NameLabel" style="#587539"/>
+  <entry type="NameNamespace" style="#8c6c3e"/>
+  <entry type="NameProperty" style="#8c6c3e"/>
+  <entry type="NameTag" style="#9854f1"/>
+  <entry type="NameVariable" style="#3760bf"/>
+  <entry type="NameVariableClass" style="#3760bf"/>
+  <entry type="NameVariableGlobal" style="#3760bf"/>
+  <entry type="NameVariableInstance" style="#3760bf"/>
+  <entry type="NameVariableMagic" style="#3760bf"/>
+  <entry type="NameAttribute" style="#2e7de9"/>
+  <entry type="NameBuiltin" style="#587539"/>
+  <entry type="NameBuiltinPseudo" style="#587539"/>
+  <entry type="NameOther" style="#3760bf"/>
+  <entry type="Literal" style="#3760bf"/>
+  <entry type="LiteralDate" style="#3760bf"/>
+  <entry type="LiteralString" style="#587539"/>
+  <entry type="LiteralStringChar" style="#587539"/>
+  <entry type="LiteralStringSingle" style="#587539"/>
+  <entry type="LiteralStringDouble" style="#587539"/>
+  <entry type="LiteralStringBacktick" style="#587539"/>
+  <entry type="LiteralStringOther" style="#587539"/>
+  <entry type="LiteralStringSymbol" style="#587539"/>
+  <entry type="LiteralStringInterpol" style="#587539"/>
+  <entry type="LiteralStringAffix" style="#9d7cd8"/>
+  <entry type="LiteralStringDelimiter" style="#2e7de9"/>
+  <entry type="LiteralStringEscape" style="#2e7de9"/>
+  <entry type="LiteralStringRegex" style="#007197"/>
+  <entry type="LiteralStringDoc" style="#a1a6c5"/>
+  <entry type="LiteralStringHeredoc" style="#a1a6c5"/>
+  <entry type="LiteralNumber" style="#8c6c3e"/>
+  <entry type="LiteralNumberBin" style="#8c6c3e"/>
+  <entry type="LiteralNumberHex" style="#8c6c3e"/>
+  <entry type="LiteralNumberInteger" style="#8c6c3e"/>
+  <entry type="LiteralNumberFloat" style="#8c6c3e"/>
+  <entry type="LiteralNumberIntegerLong" style="#8c6c3e"/>
+  <entry type="LiteralNumberOct" style="#8c6c3e"/>
+  <entry type="Operator" style="bold #587539"/>
+  <entry type="OperatorWord" style="bold #587539"/>
+  <entry type="Comment" style="italic #a1a6c5"/>
+  <entry type="CommentSingle" style="italic #a1a6c5"/>
+  <entry type="CommentMultiline" style="italic #a1a6c5"/>
+  <entry type="CommentSpecial" style="italic #a1a6c5"/>
+  <entry type="CommentHashbang" style="italic #a1a6c5"/>
+  <entry type="CommentPreproc" style="italic #a1a6c5"/>
+  <entry type="CommentPreprocFile" style="bold #a1a6c5"/>
+  <entry type="Generic" style="#3760bf"/>
+  <entry type="GenericInserted" style="bg:#e9e9ed #587539"/>
+  <entry type="GenericDeleted" style="#c64343 bg:#e9e9ed"/>
+  <entry type="GenericEmph" style="italic #3760bf"/>
+  <entry type="GenericStrong" style="bold #3760bf"/>
+  <entry type="GenericUnderline" style="underline #3760bf"/>
+  <entry type="GenericHeading" style="bold #8c6c3e"/>
+  <entry type="GenericSubheading" style="bold #8c6c3e"/>
+  <entry type="GenericOutput" style="#3760bf"/>
+  <entry type="GenericPrompt" style="#3760bf"/>
+  <entry type="GenericError" style="#c64343"/>
+  <entry type="GenericTraceback" style="#c64343"/>
+</style>

--- a/styles/tokyonight-moon.xml
+++ b/styles/tokyonight-moon.xml
@@ -1,0 +1,83 @@
+<style name="tokyonight-moon">
+  <entry type="Background" style="bg:#222436 #c8d3f5"/>
+  <entry type="CodeLine" style="#c8d3f5"/>
+  <entry type="Error" style="#c53b53"/>
+  <entry type="Other" style="#c8d3f5"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#444a73"/>
+  <entry type="LineNumbersTable" style="#828bb8"/>
+  <entry type="LineNumbers" style="#828bb8"/>
+  <entry type="Keyword" style="#c099ff"/>
+  <entry type="KeywordReserved" style="#c099ff"/>
+  <entry type="KeywordPseudo" style="#c099ff"/>
+  <entry type="KeywordConstant" style="#ffc777"/>
+  <entry type="KeywordDeclaration" style="#c099ff"/>
+  <entry type="KeywordNamespace" style="#86e1fc"/>
+  <entry type="KeywordType" style="#4fd6be"/>
+  <entry type="Name" style="#c8d3f5"/>
+  <entry type="NameClass" style="#ff966c"/>
+  <entry type="NameConstant" style="#ff966c"/>
+  <entry type="NameDecorator" style="bold #82aaff"/>
+  <entry type="NameEntity" style="#86e1fc"/>
+  <entry type="NameException" style="#ffc777"/>
+  <entry type="NameFunction" style="#82aaff"/>
+  <entry type="NameFunctionMagic" style="#82aaff"/>
+  <entry type="NameLabel" style="#c3e88d"/>
+  <entry type="NameNamespace" style="#ffc777"/>
+  <entry type="NameProperty" style="#ffc777"/>
+  <entry type="NameTag" style="#c099ff"/>
+  <entry type="NameVariable" style="#c8d3f5"/>
+  <entry type="NameVariableClass" style="#c8d3f5"/>
+  <entry type="NameVariableGlobal" style="#c8d3f5"/>
+  <entry type="NameVariableInstance" style="#c8d3f5"/>
+  <entry type="NameVariableMagic" style="#c8d3f5"/>
+  <entry type="NameAttribute" style="#82aaff"/>
+  <entry type="NameBuiltin" style="#c3e88d"/>
+  <entry type="NameBuiltinPseudo" style="#c3e88d"/>
+  <entry type="NameOther" style="#c8d3f5"/>
+  <entry type="Literal" style="#c8d3f5"/>
+  <entry type="LiteralDate" style="#c8d3f5"/>
+  <entry type="LiteralString" style="#c3e88d"/>
+  <entry type="LiteralStringChar" style="#c3e88d"/>
+  <entry type="LiteralStringSingle" style="#c3e88d"/>
+  <entry type="LiteralStringDouble" style="#c3e88d"/>
+  <entry type="LiteralStringBacktick" style="#c3e88d"/>
+  <entry type="LiteralStringOther" style="#c3e88d"/>
+  <entry type="LiteralStringSymbol" style="#c3e88d"/>
+  <entry type="LiteralStringInterpol" style="#c3e88d"/>
+  <entry type="LiteralStringAffix" style="#c099ff"/>
+  <entry type="LiteralStringDelimiter" style="#82aaff"/>
+  <entry type="LiteralStringEscape" style="#82aaff"/>
+  <entry type="LiteralStringRegex" style="#86e1fc"/>
+  <entry type="LiteralStringDoc" style="#444a73"/>
+  <entry type="LiteralStringHeredoc" style="#444a73"/>
+  <entry type="LiteralNumber" style="#ffc777"/>
+  <entry type="LiteralNumberBin" style="#ffc777"/>
+  <entry type="LiteralNumberHex" style="#ffc777"/>
+  <entry type="LiteralNumberInteger" style="#ffc777"/>
+  <entry type="LiteralNumberFloat" style="#ffc777"/>
+  <entry type="LiteralNumberIntegerLong" style="#ffc777"/>
+  <entry type="LiteralNumberOct" style="#ffc777"/>
+  <entry type="Operator" style="bold #c3e88d"/>
+  <entry type="OperatorWord" style="bold #c3e88d"/>
+  <entry type="Comment" style="italic #444a73"/>
+  <entry type="CommentSingle" style="italic #444a73"/>
+  <entry type="CommentMultiline" style="italic #444a73"/>
+  <entry type="CommentSpecial" style="italic #444a73"/>
+  <entry type="CommentHashbang" style="italic #444a73"/>
+  <entry type="CommentPreproc" style="italic #444a73"/>
+  <entry type="CommentPreprocFile" style="bold #444a73"/>
+  <entry type="Generic" style="#c8d3f5"/>
+  <entry type="GenericInserted" style="bg:#1b1d2b #c3e88d"/>
+  <entry type="GenericDeleted" style="#c53b53 bg:#1b1d2b"/>
+  <entry type="GenericEmph" style="italic #c8d3f5"/>
+  <entry type="GenericStrong" style="bold #c8d3f5"/>
+  <entry type="GenericUnderline" style="underline #c8d3f5"/>
+  <entry type="GenericHeading" style="bold #ffc777"/>
+  <entry type="GenericSubheading" style="bold #ffc777"/>
+  <entry type="GenericOutput" style="#c8d3f5"/>
+  <entry type="GenericPrompt" style="#c8d3f5"/>
+  <entry type="GenericError" style="#c53b53"/>
+  <entry type="GenericTraceback" style="#c53b53"/>
+</style>

--- a/styles/tokyonight-night.xml
+++ b/styles/tokyonight-night.xml
@@ -1,0 +1,83 @@
+<style name="tokyonight-night">
+  <entry type="Background" style="bg:#1a1b26 #c0caf5"/>
+  <entry type="CodeLine" style="#c0caf5"/>
+  <entry type="Error" style="#db4b4b"/>
+  <entry type="Other" style="#c0caf5"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#414868"/>
+  <entry type="LineNumbersTable" style="#a9b1d6"/>
+  <entry type="LineNumbers" style="#a9b1d6"/>
+  <entry type="Keyword" style="#bb9af7"/>
+  <entry type="KeywordReserved" style="#bb9af7"/>
+  <entry type="KeywordPseudo" style="#bb9af7"/>
+  <entry type="KeywordConstant" style="#e0af68"/>
+  <entry type="KeywordDeclaration" style="#9d7cd8"/>
+  <entry type="KeywordNamespace" style="#7dcfff"/>
+  <entry type="KeywordType" style="#41a6b5"/>
+  <entry type="Name" style="#c0caf5"/>
+  <entry type="NameClass" style="#ff9e64"/>
+  <entry type="NameConstant" style="#ff9e64"/>
+  <entry type="NameDecorator" style="bold #7aa2f7"/>
+  <entry type="NameEntity" style="#7dcfff"/>
+  <entry type="NameException" style="#e0af68"/>
+  <entry type="NameFunction" style="#7aa2f7"/>
+  <entry type="NameFunctionMagic" style="#7aa2f7"/>
+  <entry type="NameLabel" style="#9ece6a"/>
+  <entry type="NameNamespace" style="#e0af68"/>
+  <entry type="NameProperty" style="#e0af68"/>
+  <entry type="NameTag" style="#bb9af7"/>
+  <entry type="NameVariable" style="#c0caf5"/>
+  <entry type="NameVariableClass" style="#c0caf5"/>
+  <entry type="NameVariableGlobal" style="#c0caf5"/>
+  <entry type="NameVariableInstance" style="#c0caf5"/>
+  <entry type="NameVariableMagic" style="#c0caf5"/>
+  <entry type="NameAttribute" style="#7aa2f7"/>
+  <entry type="NameBuiltin" style="#9ece6a"/>
+  <entry type="NameBuiltinPseudo" style="#9ece6a"/>
+  <entry type="NameOther" style="#c0caf5"/>
+  <entry type="Literal" style="#c0caf5"/>
+  <entry type="LiteralDate" style="#c0caf5"/>
+  <entry type="LiteralString" style="#9ece6a"/>
+  <entry type="LiteralStringChar" style="#9ece6a"/>
+  <entry type="LiteralStringSingle" style="#9ece6a"/>
+  <entry type="LiteralStringDouble" style="#9ece6a"/>
+  <entry type="LiteralStringBacktick" style="#9ece6a"/>
+  <entry type="LiteralStringOther" style="#9ece6a"/>
+  <entry type="LiteralStringSymbol" style="#9ece6a"/>
+  <entry type="LiteralStringInterpol" style="#9ece6a"/>
+  <entry type="LiteralStringAffix" style="#9d7cd8"/>
+  <entry type="LiteralStringDelimiter" style="#7aa2f7"/>
+  <entry type="LiteralStringEscape" style="#7aa2f7"/>
+  <entry type="LiteralStringRegex" style="#7dcfff"/>
+  <entry type="LiteralStringDoc" style="#414868"/>
+  <entry type="LiteralStringHeredoc" style="#414868"/>
+  <entry type="LiteralNumber" style="#e0af68"/>
+  <entry type="LiteralNumberBin" style="#e0af68"/>
+  <entry type="LiteralNumberHex" style="#e0af68"/>
+  <entry type="LiteralNumberInteger" style="#e0af68"/>
+  <entry type="LiteralNumberFloat" style="#e0af68"/>
+  <entry type="LiteralNumberIntegerLong" style="#e0af68"/>
+  <entry type="LiteralNumberOct" style="#e0af68"/>
+  <entry type="Operator" style="bold #9ece6a"/>
+  <entry type="OperatorWord" style="bold #9ece6a"/>
+  <entry type="Comment" style="italic #414868"/>
+  <entry type="CommentSingle" style="italic #414868"/>
+  <entry type="CommentMultiline" style="italic #414868"/>
+  <entry type="CommentSpecial" style="italic #414868"/>
+  <entry type="CommentHashbang" style="italic #414868"/>
+  <entry type="CommentPreproc" style="italic #414868"/>
+  <entry type="CommentPreprocFile" style="bold #414868"/>
+  <entry type="Generic" style="#c0caf5"/>
+  <entry type="GenericInserted" style="bg:#15161e #9ece6a"/>
+  <entry type="GenericDeleted" style="#db4b4b bg:#15161e"/>
+  <entry type="GenericEmph" style="italic #c0caf5"/>
+  <entry type="GenericStrong" style="bold #c0caf5"/>
+  <entry type="GenericUnderline" style="underline #c0caf5"/>
+  <entry type="GenericHeading" style="bold #e0af68"/>
+  <entry type="GenericSubheading" style="bold #e0af68"/>
+  <entry type="GenericOutput" style="#c0caf5"/>
+  <entry type="GenericPrompt" style="#c0caf5"/>
+  <entry type="GenericError" style="#db4b4b"/>
+  <entry type="GenericTraceback" style="#db4b4b"/>
+</style>

--- a/styles/tokyonight-storm.xml
+++ b/styles/tokyonight-storm.xml
@@ -1,0 +1,83 @@
+<style name="tokyonight-storm">
+  <entry type="Background" style="bg:#1a1b26 #c0caf5"/>
+  <entry type="CodeLine" style="#c0caf5"/>
+  <entry type="Error" style="#db4b4b"/>
+  <entry type="Other" style="#c0caf5"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#414868"/>
+  <entry type="LineNumbersTable" style="#a9b1d6"/>
+  <entry type="LineNumbers" style="#a9b1d6"/>
+  <entry type="Keyword" style="#bb9af7"/>
+  <entry type="KeywordReserved" style="#bb9af7"/>
+  <entry type="KeywordPseudo" style="#bb9af7"/>
+  <entry type="KeywordConstant" style="#e0af68"/>
+  <entry type="KeywordDeclaration" style="#9d7cd8"/>
+  <entry type="KeywordNamespace" style="#7dcfff"/>
+  <entry type="KeywordType" style="#41a6b5"/>
+  <entry type="Name" style="#c0caf5"/>
+  <entry type="NameClass" style="#ff9e64"/>
+  <entry type="NameConstant" style="#ff9e64"/>
+  <entry type="NameDecorator" style="bold #7aa2f7"/>
+  <entry type="NameEntity" style="#7dcfff"/>
+  <entry type="NameException" style="#e0af68"/>
+  <entry type="NameFunction" style="#7aa2f7"/>
+  <entry type="NameFunctionMagic" style="#7aa2f7"/>
+  <entry type="NameLabel" style="#9ece6a"/>
+  <entry type="NameNamespace" style="#e0af68"/>
+  <entry type="NameProperty" style="#e0af68"/>
+  <entry type="NameTag" style="#bb9af7"/>
+  <entry type="NameVariable" style="#c0caf5"/>
+  <entry type="NameVariableClass" style="#c0caf5"/>
+  <entry type="NameVariableGlobal" style="#c0caf5"/>
+  <entry type="NameVariableInstance" style="#c0caf5"/>
+  <entry type="NameVariableMagic" style="#c0caf5"/>
+  <entry type="NameAttribute" style="#7aa2f7"/>
+  <entry type="NameBuiltin" style="#9ece6a"/>
+  <entry type="NameBuiltinPseudo" style="#9ece6a"/>
+  <entry type="NameOther" style="#c0caf5"/>
+  <entry type="Literal" style="#c0caf5"/>
+  <entry type="LiteralDate" style="#c0caf5"/>
+  <entry type="LiteralString" style="#9ece6a"/>
+  <entry type="LiteralStringChar" style="#9ece6a"/>
+  <entry type="LiteralStringSingle" style="#9ece6a"/>
+  <entry type="LiteralStringDouble" style="#9ece6a"/>
+  <entry type="LiteralStringBacktick" style="#9ece6a"/>
+  <entry type="LiteralStringOther" style="#9ece6a"/>
+  <entry type="LiteralStringSymbol" style="#9ece6a"/>
+  <entry type="LiteralStringInterpol" style="#9ece6a"/>
+  <entry type="LiteralStringAffix" style="#9d7cd8"/>
+  <entry type="LiteralStringDelimiter" style="#7aa2f7"/>
+  <entry type="LiteralStringEscape" style="#7aa2f7"/>
+  <entry type="LiteralStringRegex" style="#7dcfff"/>
+  <entry type="LiteralStringDoc" style="#414868"/>
+  <entry type="LiteralStringHeredoc" style="#414868"/>
+  <entry type="LiteralNumber" style="#e0af68"/>
+  <entry type="LiteralNumberBin" style="#e0af68"/>
+  <entry type="LiteralNumberHex" style="#e0af68"/>
+  <entry type="LiteralNumberInteger" style="#e0af68"/>
+  <entry type="LiteralNumberFloat" style="#e0af68"/>
+  <entry type="LiteralNumberIntegerLong" style="#e0af68"/>
+  <entry type="LiteralNumberOct" style="#e0af68"/>
+  <entry type="Operator" style="bold #9ece6a"/>
+  <entry type="OperatorWord" style="bold #9ece6a"/>
+  <entry type="Comment" style="italic #414868"/>
+  <entry type="CommentSingle" style="italic #414868"/>
+  <entry type="CommentMultiline" style="italic #414868"/>
+  <entry type="CommentSpecial" style="italic #414868"/>
+  <entry type="CommentHashbang" style="italic #414868"/>
+  <entry type="CommentPreproc" style="italic #414868"/>
+  <entry type="CommentPreprocFile" style="bold #414868"/>
+  <entry type="Generic" style="#c0caf5"/>
+  <entry type="GenericInserted" style="bg:#15161e #9ece6a"/>
+  <entry type="GenericDeleted" style="#db4b4b bg:#15161e"/>
+  <entry type="GenericEmph" style="italic #c0caf5"/>
+  <entry type="GenericStrong" style="bold #c0caf5"/>
+  <entry type="GenericUnderline" style="underline #c0caf5"/>
+  <entry type="GenericHeading" style="bold #e0af68"/>
+  <entry type="GenericSubheading" style="bold #e0af68"/>
+  <entry type="GenericOutput" style="#c0caf5"/>
+  <entry type="GenericPrompt" style="#c0caf5"/>
+  <entry type="GenericError" style="#db4b4b"/>
+  <entry type="GenericTraceback" style="#db4b4b"/>
+</style>


### PR DESCRIPTION
Add [`tokyonight`](https://github.com/folke/tokyonight.nvim) based styles.

`tokyonight-storm`
![image](https://github.com/alecthomas/chroma/assets/127410436/0a051a42-2131-4dd1-8927-35630da0529b)
`tokyonight-day`
![image](https://github.com/alecthomas/chroma/assets/127410436/bd6fcfe8-f0c0-4e0d-a53b-29fdc887712b)
`tokyonight-moon`
![image](https://github.com/alecthomas/chroma/assets/127410436/8aca5af6-86c9-4d8e-badd-539aa5399fba)
`tokyonight-night`
![image](https://github.com/alecthomas/chroma/assets/127410436/7b61d34a-e469-4f63-a7cc-fa385c1f6943)

