### PR TITLE
Fix stack popping logic in Raku lexer

### DIFF
--- a/lexers/raku.go
+++ b/lexers/raku.go
@@ -1366,11 +1366,11 @@ func popRule(rule ruleReplacingConfig) MutatorFunc {
 
 		if ok && len(stack) > 0 {
 			// Pop from stack
-			stack = stack[:len(stack)-1]
 			lastRule := stack[len(stack)-1]
 			lastRule.pushState = false
 			lastRule.popState = false
 			lastRule.pop = true
+			stack = stack[:len(stack)-1]
 			state.Set(stackName, stack)
 
 			// Call replaceRule to use the last rule


### PR DESCRIPTION
This fixes an array index bounds error.