### PR TITLE
feat(lexers/hare): add done keyword

### DIFF
--- a/lexers/embedded/hare.xml
+++ b/lexers/embedded/hare.xml
@@ -84,7 +84,7 @@
           <token type="Punctuation" />
         </bygroups>
       </rule>
-      <rule pattern="(str|size|rune|bool|int|uint|uintptr|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|null|void|nullable|valist|opaque|never)\b">
+      <rule pattern="(str|size|rune|bool|int|uint|uintptr|u8|u16|u32|u64|i8|i16|i32|i64|f32|f64|null|void|done|nullable|valist|opaque|never)\b">
         <token type="KeywordType"/>
       </rule>
       <rule pattern="(true|false)\b">


### PR DESCRIPTION
Adds the `done` keyword described in [this blog post](https://harelang.org/blog/2024-04-01-introducing-for-each-loops-in-hare/) and introduced in [0.24.2-rc1](https://lists.sr.ht/~sircmpwn/hare-dev/%3CD2FVIMECX52X.2MYXMW7OG4UIK@cmpwn.com%3E).