### PR TITLE
pygments2chroma: escape regex.words

### DIFF
--- a/_tools/pygments2chroma_xml.py
+++ b/_tools/pygments2chroma_xml.py
@@ -128,7 +128,7 @@ def translate_rules(rules):
                 regex = xml_regex(regex)
             elif isinstance(regex, pygments_lexer.words):
                 regex = xml_string('%s(%s)%s' % (regex.prefix,
-                                      '|'.join(w for w in regex.words),
+                                      '|'.join(re.escape(w) for w in regex.words),
                                       regex.suffix))
             else:
                 raise ValueError('expected regex string but got %r' % regex)


### PR DESCRIPTION
Discovered while building on top of https://github.com/alecthomas/chroma/issues/877#issuecomment-1858982870 (by @miliog)

The pygments "regex.words" should be escaped, since they may contain special regex chars (like `^` or `+`).