### PR TITLE
Update GitHub light color palette

### DIFF
--- a/styles/github.xml
+++ b/styles/github.xml
@@ -1,44 +1,39 @@
 <style name="github">
-  <entry type="Error" style="#a61717 bg:#e3d2d2"/>
+  <entry type="Error" style="#f6f8fa bg:#82071e"/>
   <entry type="Background" style="bg:#ffffff"/>
-  <entry type="Keyword" style="bold #000000"/>
-  <entry type="KeywordType" style="bold #445588"/>
-  <entry type="NameAttribute" style="#008080"/>
-  <entry type="NameBuiltin" style="#0086b3"/>
-  <entry type="NameBuiltinPseudo" style="#999999"/>
-  <entry type="NameClass" style="bold #445588"/>
-  <entry type="NameConstant" style="#008080"/>
-  <entry type="NameDecorator" style="bold #3c5d5d"/>
-  <entry type="NameEntity" style="#800080"/>
-  <entry type="NameException" style="bold #990000"/>
-  <entry type="NameFunction" style="bold #990000"/>
+  <entry type="Keyword" style="#cf222e"/>
+  <entry type="KeywordType" style="#cf222e"/>
+  <entry type="NameAttribute" style="#1f2328"/>
+  <entry type="NameBuiltin" style="#6639ba"/>
+  <entry type="NameBuiltinPseudo" style="#6a737d"/>
+  <entry type="NameClass" style="#1f2328"/>
+  <entry type="NameConstant" style="#0550ae"/>
+  <entry type="NameDecorator" style="#0550ae"/>
+  <entry type="NameEntity" style="#6639ba"/>
+  <entry type="NameFunction" style="#6639ba"/>
   <entry type="NameLabel" style="bold #990000"/>
-  <entry type="NameNamespace" style="#555555"/>
-  <entry type="NameTag" style="#000080"/>
-  <entry type="NameVariable" style="#008080"/>
-  <entry type="NameVariableClass" style="#008080"/>
-  <entry type="NameVariableGlobal" style="#008080"/>
-  <entry type="NameVariableInstance" style="#008080"/>
-  <entry type="LiteralString" style="#dd1144"/>
-  <entry type="LiteralStringRegex" style="#009926"/>
-  <entry type="LiteralStringSymbol" style="#990073"/>
-  <entry type="LiteralNumber" style="#009999"/>
-  <entry type="Operator" style="bold #000000"/>
-  <entry type="Comment" style="italic #999988"/>
-  <entry type="CommentMultiline" style="italic #999988"/>
-  <entry type="CommentSingle" style="italic #999988"/>
-  <entry type="CommentSpecial" style="bold italic #999999"/>
-  <entry type="CommentPreproc" style="bold #999999"/>
-  <entry type="GenericDeleted" style="#000000 bg:#ffdddd"/>
-  <entry type="GenericEmph" style="italic #000000"/>
-  <entry type="GenericError" style="#aa0000"/>
-  <entry type="GenericHeading" style="#999999"/>
-  <entry type="GenericInserted" style="#000000 bg:#ddffdd"/>
-  <entry type="GenericOutput" style="#888888"/>
-  <entry type="GenericPrompt" style="#555555"/>
-  <entry type="GenericStrong" style="bold"/>
-  <entry type="GenericSubheading" style="#aaaaaa"/>
-  <entry type="GenericTraceback" style="#aa0000"/>
+  <entry type="NameNamespace" style="#24292e"/>
+  <entry type="NameOther" style="#1f2328"/>
+  <entry type="NameTag" style="#0550ae"/>
+  <entry type="NameVariable" style="#953800"/>
+  <entry type="NameVariableClass" style="#953800"/>
+  <entry type="NameVariableGlobal" style="#953800"/>
+  <entry type="NameVariableInstance" style="#953800"/>
+  <entry type="LiteralString" style="#0a3069"/>
+  <entry type="LiteralStringRegex" style="#0a3069"/>
+  <entry type="LiteralStringSymbol" style="#032f62"/>
+  <entry type="LiteralNumber" style="#0550ae"/>
+  <entry type="Operator" style="#0550ae"/>
+  <entry type="Comment" style="#57606a"/>
+  <entry type="CommentMultiline" style="#57606a"/>
+  <entry type="CommentSingle" style="#57606a"/>
+  <entry type="CommentSpecial" style="#57606a"/>
+  <entry type="CommentPreproc" style="#57606a"/>
+  <entry type="GenericDeleted" style="#82071e bg:#ffebe9"/>
+  <entry type="GenericEmph" style="#1f2328"/>
+  <entry type="GenericInserted" style="#116329 bg:#dafbe1"/>
+  <entry type="GenericOutput" style="#1f2328"/>
   <entry type="GenericUnderline" style="underline"/>
-  <entry type="TextWhitespace" style="#bbbbbb"/>
+  <entry type="Punctuation" style="#1f2328"/>
+  <entry type="TextWhitespace" style="#ffffff"/>
 </style>


### PR DESCRIPTION
I noticed that the current syntax highlighting generator uses an older color palette that doesn’t reflect GitHub’s latest light theme, which now features lighter, pastel tones for improved readability and accessibility. I’ve updated the color scheme to match the newer colors.

I was wondering if it makes sense to adopt these changes or, if maintaining the current color scheme is essential, whether it would be better to publish this as a separate variant under a different name.

## Example

### Before 
![before](https://github.com/user-attachments/assets/7cb6f80b-f7c5-4071-8531-5aa7c338bcf4)

### After
![after](https://github.com/user-attachments/assets/dfb7930d-4ef5-4797-bf6c-2a35ae23d43e)
