### PR TITLE
Pager friendly terminal formatting

### DIFF
--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -1,7 +1,6 @@
 package formatters
 
 import (
-	"fmt"
 	"io"
 	"math"
 
@@ -257,13 +256,7 @@ func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma
 			}
 		}
 
-		if clr != "" {
-			fmt.Fprint(w, clr)
-		}
-		fmt.Fprint(w, token.Value)
-		if clr != "" {
-			fmt.Fprintf(w, "\033[0m")
-		}
+		writeToken(w, clr, token.Value)
 	}
 	return nil
 }

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -14,29 +14,32 @@ func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) e
 	style = clearBackground(style)
 	for token := it(); token != chroma.EOF; token = it() {
 		entry := style.Get(token.Type)
-		if !entry.IsZero() {
-			out := ""
-			if entry.Bold == chroma.Yes {
-				out += "\033[1m"
-			}
-			if entry.Underline == chroma.Yes {
-				out += "\033[4m"
-			}
-			if entry.Italic == chroma.Yes {
-				out += "\033[3m"
-			}
-			if entry.Colour.IsSet() {
-				out += fmt.Sprintf("\033[38;2;%d;%d;%dm", entry.Colour.Red(), entry.Colour.Green(), entry.Colour.Blue())
-			}
-			if entry.Background.IsSet() {
-				out += fmt.Sprintf("\033[48;2;%d;%d;%dm", entry.Background.Red(), entry.Background.Green(), entry.Background.Blue())
-			}
-			fmt.Fprint(w, out)
+		if entry.IsZero() {
+			fmt.Fprint(w, token.Value)
+			continue
 		}
+
+		out := ""
+		if entry.Bold == chroma.Yes {
+			out += "\033[1m"
+		}
+		if entry.Underline == chroma.Yes {
+			out += "\033[4m"
+		}
+		if entry.Italic == chroma.Yes {
+			out += "\033[3m"
+		}
+		if entry.Colour.IsSet() {
+			out += fmt.Sprintf("\033[38;2;%d;%d;%dm", entry.Colour.Red(), entry.Colour.Green(), entry.Colour.Blue())
+		}
+		if entry.Background.IsSet() {
+			out += fmt.Sprintf("\033[48;2;%d;%d;%dm", entry.Background.Red(), entry.Background.Green(), entry.Background.Blue())
+		}
+		fmt.Fprint(w, out)
+
 		fmt.Fprint(w, token.Value)
-		if !entry.IsZero() {
-			fmt.Fprint(w, "\033[0m")
-		}
+
+		fmt.Fprint(w, "\033[0m")
 	}
 	return nil
 }

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -18,7 +18,12 @@ var crOrCrLf = regexp.MustCompile(`\r?\n`)
 //
 // This way, a pager (like https://github.com/walles/moar for example) can show
 // any line in the output by itself, and it will get the right formatting.
-func trueColorTokenFormatter(w io.Writer, formatting string, text string) {
+func writeToken(w io.Writer, formatting string, text string) {
+	if formatting == "" {
+		fmt.Fprint(w, text)
+		return
+	}
+
 	newlineIndices := crOrCrLf.FindAllStringIndex(text, -1)
 
 	afterLastNewline := 0
@@ -65,7 +70,7 @@ func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) e
 			formatting += fmt.Sprintf("\033[48;2;%d;%d;%dm", entry.Background.Red(), entry.Background.Green(), entry.Background.Blue())
 		}
 
-		trueColorTokenFormatter(w, formatting, token.Value)
+		writeToken(w, formatting, token.Value)
 	}
 	return nil
 }


### PR DESCRIPTION
Let's say a pager, like [moar](https://github.com/walles/moar) (uses Chroma for syntax highlighting) or `less`, shows a line in the middle of a file.

Unless that line starts with the correct formatting for the line, the pager would have to scan the whole file from the start to get the coloring of this single line right.

Before this PR, lines were not guaranteed to start with formatting, but could sometimes rely on formatting from the preceding lines.

With this change in place, lines can now stand by themselves, and paging will work better on Chroma's output.

Missing formatting at the start of the line would happen when a token had a linefeed in the middle.