### PR TITLE
add any as a builtin type for go

### DIFF
--- a/lexers/go.go
+++ b/lexers/go.go
@@ -38,7 +38,7 @@ func goRules() Rules {
 			{Words(``, `\b`, `break`, `default`, `select`, `case`, `defer`, `go`, `else`, `goto`, `switch`, `fallthrough`, `if`, `range`, `continue`, `for`, `return`), Keyword, nil},
 			{`(true|false|iota|nil)\b`, KeywordConstant, nil},
 			{Words(``, `\b(\()`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `int`, `int8`, `int16`, `int32`, `int64`, `float`, `float32`, `float64`, `complex64`, `complex128`, `byte`, `rune`, `string`, `bool`, `error`, `uintptr`, `print`, `println`, `panic`, `recover`, `close`, `complex`, `real`, `imag`, `len`, `cap`, `append`, `copy`, `delete`, `new`, `make`, `clear`, `min`, `max`), ByGroups(NameBuiltin, Punctuation), nil},
-			{Words(``, `\b`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `int`, `int8`, `int16`, `int32`, `int64`, `float`, `float32`, `float64`, `complex64`, `complex128`, `byte`, `rune`, `string`, `bool`, `error`, `uintptr`), KeywordType, nil},
+			{Words(``, `\b`, `uint`, `uint8`, `uint16`, `uint32`, `uint64`, `int`, `int8`, `int16`, `int32`, `int64`, `float`, `float32`, `float64`, `complex64`, `complex128`, `byte`, `rune`, `string`, `bool`, `error`, `uintptr`, `any`), KeywordType, nil},
 			{`\d+i`, LiteralNumber, nil},
 			{`\d+\.\d*([Ee][-+]\d+)?i`, LiteralNumber, nil},
 			{`\.\d+([Ee][-+]\d+)?i`, LiteralNumber, nil},


### PR DESCRIPTION
Thanks for this awesome go module.

I have noticed that the builtin `any` type in Go isn't highlighted, so i have added it in this PR. :)