### PR TITLE
fix(nix): nix lexor missing '=' operator

### DIFF
--- a/lexers/embedded/nix.xml
+++ b/lexers/embedded/nix.xml
@@ -106,7 +106,7 @@
         </bygroups>
         <push state="interpol"/>
       </rule>
-      <rule pattern="(&amp;&amp;|&gt;=|&lt;=|\+\+|-&gt;|!=|\|\||//|==|@|!|\+|\?|&lt;|\.|&gt;|\*)">
+      <rule pattern="(&amp;&amp;|&gt;=|&lt;=|\+\+|-&gt;|!=|=|\|\||//|==|@|!|\+|\?|&lt;|\.|&gt;|\*)">
         <token type="Operator"/>
       </rule>
       <rule pattern="[;:]">


### PR DESCRIPTION
The nix lexor was missing the '=' operator in the operators rule. This meant that in some cases (like the first '=' in a code block), it would return an err instead of the proper highlighting.

Before:
![screenshot](https://github.com/user-attachments/assets/a34dd5e1-ea6b-4898-a8ef-81cf9b9f40fe)
After:
![screenshot](https://github.com/user-attachments/assets/eb59697c-b828-4c33-bb12-19f67432a99d)
