### PR TITLE
Choose to clear background for TTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ style := styles.Get("swapoff")
 if style == nil {
   style = styles.Fallback
 }
-style, _ = ClearBackground()
+style, _ = style.ClearBackground()
 
 formatter := formatters.Get("html")
 if formatter == nil {

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ style := styles.Get("swapoff")
 if style == nil {
   style = styles.Fallback
 }
+style, _ = ClearBackground()
+
 formatter := formatters.Get("html")
 if formatter == nil {
   formatter = formatters.Fallback

--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -223,9 +223,13 @@ func styleToEscapeSequence(table *ttyTable, style *chroma.Style) map[chroma.Toke
 
 type indexedTTYFormatter struct {
 	table *ttyTable
+	enabledBackground bool
 }
 
 func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma.Iterator) (err error) {
+	if !c.enabledBackground {
+		style, _ = style.ClearBackground()
+	}
 	theme := styleToEscapeSequence(c.table, style)
 	for token := it(); token != chroma.EOF; token = it() {
 		clr, ok := theme[token.Type]
@@ -252,21 +256,43 @@ func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma
 // TTY is an 8-colour terminal formatter.
 //
 // The Lab colour space is used to map RGB values to the most appropriate index colour.
-var TTY = Register("terminal", &indexedTTYFormatter{ttyTables[8]})
+var TTY = Register("terminal", &indexedTTYFormatter{ttyTables[8], false})
 
 // TTY8 is an 8-colour terminal formatter.
 //
 // The Lab colour space is used to map RGB values to the most appropriate index colour.
-var TTY8 = Register("terminal8", &indexedTTYFormatter{ttyTables[8]})
+var TTY8 = Register("terminal8", &indexedTTYFormatter{ttyTables[8], false})
 
 // TTY16 is a 16-colour terminal formatter.
 //
 // It uses \033[3xm for normal colours and \033[90Xm for bright colours.
 //
 // The Lab colour space is used to map RGB values to the most appropriate index colour.
-var TTY16 = Register("terminal16", &indexedTTYFormatter{ttyTables[16]})
+var TTY16 = Register("terminal16", &indexedTTYFormatter{ttyTables[16], false})
 
 // TTY256 is a 256-colour terminal formatter.
 //
 // The Lab colour space is used to map RGB values to the most appropriate index colour.
-var TTY256 = Register("terminal256", &indexedTTYFormatter{ttyTables[256]})
+var TTY256 = Register("terminal256", &indexedTTYFormatter{ttyTables[256], false})
+
+// TTY BG is an 8-colour terminal formatter with background colour enabled.
+//
+// The Lab colour space is used to map RGB values to the most appropriate index colour.
+var TTYBG = Register("terminalBG", &indexedTTYFormatter{ttyTables[8], true})
+
+// TTY8 BG is an 8-colour terminal formatter with background colour enabled.
+//
+// The Lab colour space is used to map RGB values to the most appropriate index colour.
+var TTY8BG = Register("terminal8BG", &indexedTTYFormatter{ttyTables[8], true})
+
+// TTY16 BG is a 16-colour terminal formatter with background colour enabled.
+//
+// It uses \033[3xm for normal colours and \033[90Xm for bright colours.
+//
+// The Lab colour space is used to map RGB values to the most appropriate index colour.
+var TTY16BG = Register("terminal16BG", &indexedTTYFormatter{ttyTables[16], true})
+
+// TTY256 BG is a 256-colour terminal formatter with background colour enabled.
+//
+// The Lab colour space is used to map RGB values to the most appropriate index colour.
+var TTY256BG = Register("terminal256BG", &indexedTTYFormatter{ttyTables[256], true})

--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -213,24 +213,12 @@ func findClosest(table *ttyTable, seeking chroma.Colour) chroma.Colour {
 }
 
 func styleToEscapeSequence(table *ttyTable, style *chroma.Style) map[chroma.TokenType]string {
-	style = clearBackground(style)
 	out := map[chroma.TokenType]string{}
 	for _, ttype := range style.Types() {
 		entry := style.Get(ttype)
 		out[ttype] = entryToEscapeSequence(table, entry)
 	}
 	return out
-}
-
-// Clear the background colour.
-func clearBackground(style *chroma.Style) *chroma.Style {
-	builder := style.Builder()
-	bg := builder.Get(chroma.Background)
-	bg.Background = 0
-	bg.NoInherit = true
-	builder.AddEntry(chroma.Background, bg)
-	style, _ = builder.Build()
-	return style
 }
 
 type indexedTTYFormatter struct {

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -9,7 +9,10 @@ import (
 )
 
 // TTY16m is a true-colour terminal formatter.
-var TTY16m = Register("terminal16m", chroma.FormatterFunc(trueColourFormatter))
+var TTY16m = Register("terminal16m", chroma.FormatterFunc(trueColour))
+
+// TTY16mBG is a true-colour terminal formatter with Background colours enabled.
+var TTY16mBG = Register("terminal16mBG", chroma.FormatterFunc(trueColourBG))
 
 var crOrCrLf = regexp.MustCompile(`\r?\n`)
 
@@ -44,7 +47,15 @@ func writeToken(w io.Writer, formatting string, text string) {
 	}
 }
 
-func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
+func trueColour(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
+	style, _ = style.ClearBackground()
+	return Formatter(w, style, it)
+}
+func trueColourBG(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
+	return Formatter(w, style, it)
+}
+
+func Formatter(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
 	for token := it(); token != chroma.EOF; token = it() {
 		entry := style.Get(token.Type)
 		if entry.IsZero() {

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -45,7 +45,6 @@ func writeToken(w io.Writer, formatting string, text string) {
 }
 
 func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
-	style = clearBackground(style)
 	for token := it(); token != chroma.EOF; token = it() {
 		entry := style.Get(token.Type)
 		if entry.IsZero() {

--- a/style.go
+++ b/style.go
@@ -262,6 +262,15 @@ type Style struct {
 	parent  *Style
 }
 
+func (s *Style) ClearBackground() (*Style, error) {
+	builder := s.Builder()
+	bg := s.get(Background)
+	bg.Background = 0
+	bg.NoInherit = true
+	builder.AddEntry(Background, bg)
+	return builder.Build()
+}
+
 func (s *Style) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if s.parent != nil {
 		return fmt.Errorf("cannot marshal style with parent")


### PR DESCRIPTION
I want to be able to have a background colour for the output in tty. This would help in getting a nicer looking code snippet in projects like https://charm.sh/.

The functionality of clearing the background is still present. But now it is done explicitly though the style.ClearBackgound() function. An example of this would look like the following:
``` Go
func main() {
	in := `int main(int argc, char** argv) { return 0; }`

	lexer := lexers.Get("C")
	if lexer == nil {
		lexer = lexers.Fallback
	}
	style := styles.Get("monokai")
	if style == nil {
		style = styles.Fallback
	}
	formatter := formatters.Get("terminal256BG") // Formats with the BG suffix in the name have background colours enabled
	if formatter == nil {
		formatter = formatters.Fallback
	}

	iterator, _ := lexer.Tokenise(nil, string(in))
	formatter.Format(os.Stdout, style, iterator)
}
```