### PR TITLE
Add luau file extension and alias to lua lexer

### DIFF
--- a/lexers/embedded/lua.xml
+++ b/lexers/embedded/lua.xml
@@ -2,8 +2,10 @@
   <config>
     <name>Lua</name>
     <alias>lua</alias>
+    <alias>luau</alias>
     <filename>*.lua</filename>
     <filename>*.wlua</filename>
+    <filename>*.luau</filename>
     <mime_type>text/x-lua</mime_type>
     <mime_type>application/x-lua</mime_type>
   </config>


### PR DESCRIPTION
Treat `*.luau` the same as `*.lua`. Same as Linguist does:

https://github.com/github-linguist/linguist/blob/c959cb53f48552db0e42cded66f3e5a64749b9ec/lib/linguist/languages.yml#L4109-L4120