### PR TITLE
Add lexers.Aliases() method to display only lexers' aliases

### DIFF
--- a/lexers/lexers.go
+++ b/lexers/lexers.go
@@ -29,6 +29,12 @@ func Names(withAliases bool) []string {
 	return GlobalLexerRegistry.Names(withAliases)
 }
 
+// Aliases of all the lexers, and skip those lexers who do not have any aliases,
+// or show their name instead
+func Aliases(skipWithoutAliases bool) []string {
+	return GlobalLexerRegistry.Aliases(skipWithoutAliases)
+}
+
 // Get a Lexer by name, alias or file extension.
 //
 // Note that this if there isn't an exact match on name or alias, this will

--- a/lexers/lexers_test.go
+++ b/lexers/lexers_test.go
@@ -44,6 +44,19 @@ func TestGet(t *testing.T) {
 	})
 }
 
+func TestAliases(t *testing.T) {
+	t.Run("UseNameIfNoAliases", func(t *testing.T) {
+		expected := lexers.GlobalLexerRegistry.Aliases(false)
+		actual := lexers.Aliases(false)
+		assert.Equal(t, expected, actual)
+	})
+	t.Run("SkipIfNoAliases", func(t *testing.T) {
+		expected := lexers.GlobalLexerRegistry.Aliases(true)
+		actual := lexers.Aliases(true)
+		assert.Equal(t, expected, actual)
+	})
+}
+
 func TestGlobs(t *testing.T) {
 	filename := "main.go"
 	for _, lexer := range lexers.GlobalLexerRegistry.Lexers {

--- a/registry.go
+++ b/registry.go
@@ -48,6 +48,24 @@ func (l *LexerRegistry) Names(withAliases bool) []string {
 	return out
 }
 
+// Aliases of all the lexers, and skip those lexers who do not have any aliases,
+// or show their name instead
+func (l *LexerRegistry) Aliases(skipWithoutAliases bool) []string {
+	out := []string{}
+	for _, lexer := range l.Lexers {
+		config := lexer.Config()
+		if len(config.Aliases) == 0 {
+			if skipWithoutAliases {
+				continue
+			}
+			out = append(out, config.Name)
+		}
+		out = append(out, config.Aliases...)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // Get a Lexer by name, alias or file extension.
 func (l *LexerRegistry) Get(name string) Lexer {
 	if lexer := l.byName[name]; lexer != nil {


### PR DESCRIPTION
`lexers.Aliases()` method shows all the aliases for all the available lexers, or their name if none are found. Using a flag, lexers without aliases can be skipped entirely.

This request addresses https://github.com/alecthomas/chroma/issues/1048.