### PR TITLE
styles: add proper diff styling to rrt (fix #603)

### DIFF
--- a/styles/rrt.xml
+++ b/styles/rrt.xml
@@ -10,4 +10,10 @@
   <entry type="LiteralNumber" style="#ff6600"/>
   <entry type="Comment" style="#00ff00"/>
   <entry type="CommentPreproc" style="#e5e5e5"/>
+  <entry type="GenericDeleted" style="#f00"/>
+  <entry type="GenericEmph" style="italic"/>
+  <entry type="GenericHeading" style="bold #ff0"/>
+  <entry type="GenericInserted" style="#0f0"/>
+  <entry type="GenericStrong" style="bold"/>
+  <entry type="GenericSubheading" style="bold #87ceeb"/>
 </style>


### PR DESCRIPTION
This will **at the very least** enable proper styling of `diff` files:

Before:
![image](https://github.com/user-attachments/assets/a87a2130-7fa9-4229-a164-d6b5b74cbb79)


After:
![image](https://github.com/user-attachments/assets/3e48679a-fcb9-46d3-be61-bd3cb74f2a91)

Also added GenericStrong and GenericEmph tokens since they seem to be universal (but were missing).

The styling has been kept true to the rrt theme.

Fixes #603