### PR TITLE
Fix badly-generated MoonScript lexer patterns by copying from Lua

### DIFF
--- a/lexers/embedded/moonscript.xml
+++ b/lexers/embedded/moonscript.xml
@@ -1,0 +1,74 @@
+
+<lexer>
+  <config>
+    <name>MoonScript</name>
+    <alias>moonscript</alias>
+    <alias>moon</alias>
+    <filename>*.moon</filename>
+    <mime_type>text/x-moonscript</mime_type>
+    <mime_type>application/x-moonscript</mime_type>
+  </config>
+  <rules>
+    <state name="root">
+      <rule pattern="#!(.*?)$"><token type="CommentPreproc"/></rule>
+      <rule><push state="base"/></rule>
+    </state>
+    <state name="base">
+      <rule pattern="--.*$"><token type="CommentSingle"/></rule>
+      <rule pattern="(?i)(\d*\.\d+|\d+\.\d*)(e[+-]?\d+)?"><token type="LiteralNumberFloat"/></rule>
+      <rule pattern="(?i)\d+e[+-]?\d+"><token type="LiteralNumberFloat"/></rule>
+      <rule pattern="(?i)0x[0-9a-f]*"><token type="LiteralNumberHex"/></rule>
+      <rule pattern="\d+"><token type="LiteralNumberInteger"/></rule>
+      <rule pattern="\n"><token type="TextWhitespace"/></rule>
+      <rule pattern="[^\S\n]+"><token type="Text"/></rule>
+      <rule pattern="(?s)\[(=*)\[.*?\]\1\]"><token type="LiteralString"/></rule>
+      <rule pattern="(-&gt;|=&gt;)"><token type="NameFunction"/></rule>
+      <rule pattern=":[a-zA-Z_]\w*"><token type="NameVariable"/></rule>
+      <rule pattern="(==|!=|~=|&lt;=|&gt;=|\.\.\.|\.\.|[=+\-*/%^&lt;&gt;#!.\\:])"><token type="Operator"/></rule>
+      <rule pattern="[;,]"><token type="Punctuation"/></rule>
+      <rule pattern="[\[\]{}()]"><token type="KeywordType"/></rule>
+      <rule pattern="[a-zA-Z_]\w*:"><token type="NameVariable"/></rule>
+      <rule pattern="(class|extends|if|then|super|do|with|import|export|while|elseif|return|for|in|from|when|using|else|and|or|not|switch|break)\b"><token type="Keyword"/></rule>
+      <rule pattern="(true|false|nil)\b"><token type="KeywordConstant"/></rule>
+      <rule pattern="(and|or|not)\b"><token type="OperatorWord"/></rule>
+      <rule pattern="(self)\b"><token type="NameBuiltinPseudo"/></rule>
+      <rule pattern="@@?([a-zA-Z_]\w*)?"><token type="NameVariableClass"/></rule>
+      <rule pattern="[A-Z]\w*"><token type="NameClass"/></rule>
+      <rule pattern="[A-Za-z_]\w*(\.[A-Za-z_]\w*)?"><token type="Name"/></rule>
+      <rule pattern="&#x27;"><token type="LiteralStringSingle"/><combined state="stringescape" state="sqs"/></rule>
+      <rule pattern="&quot;"><token type="LiteralStringDouble"/><combined state="stringescape" state="dqs"/></rule>
+    </state>
+    <state name="stringescape">
+      <rule pattern="\\([abfnrtv\\&quot;&#x27;]|\d{1,3})"><token type="LiteralStringEscape"/></rule>
+    </state>
+    <state name="sqs">
+      <rule pattern="&#x27;"><token type="LiteralStringSingle"/><pop depth="1"/></rule>
+      <rule pattern="[^&#x27;]+"><token type="LiteralString"/></rule>
+    </state>
+    <state name="dqs">
+      <rule pattern="&quot;"><token type="LiteralStringDouble"/><pop depth="1"/></rule>
+      <rule pattern="[^&quot;]+"><token type="LiteralString"/></rule>
+    </state>
+    <state name="ws">
+      <rule pattern="(?:--\[(=*)\[[\w\W]*?\](\1)\])"><token type="CommentMultiline"/></rule>
+      <rule pattern="(?:--.*$)"><token type="CommentSingle"/></rule>
+      <rule pattern="(?:\s+)"><token type="Text"/></rule>
+    </state>
+    <state name="funcname">
+      <rule><include state="ws"/></rule>
+      <rule pattern="[.:]"><token type="Punctuation"/></rule>
+      <rule pattern="(?:[^\W\d]\w*)(?=(?:(?:--\[(=*)\[[\w\W]*?\](\2)\])|(?:--.*$)|(?:\s+))*[.:])"><token type="NameClass"/></rule>
+      <rule pattern="(?:[^\W\d]\w*)"><token type="NameFunction"/><pop depth="1"/></rule>
+      <rule pattern="\("><token type="Punctuation"/><pop depth="1"/></rule>
+    </state>
+    <state name="goto">
+      <rule><include state="ws"/></rule>
+      <rule pattern="(?:[^\W\d]\w*)"><token type="NameLabel"/><pop depth="1"/></rule>
+    </state>
+    <state name="label">
+      <rule><include state="ws"/></rule>
+      <rule pattern="::"><token type="Punctuation"/><pop depth="1"/></rule>
+      <rule pattern="(?:[^\W\d]\w*)"><token type="NameLabel"/></rule>
+    </state>
+  </rules>
+</lexer>


### PR DESCRIPTION
## Problem

The MoonScript lexer generated by the `pygments2chroma_xml.py` script with the following command...

```
$ python3 _tools/pygments2chroma_xml.py \
  pygments.lexers.scripting.MoonScriptLexer \
  > lexers/embedded/moonscript.xml
```

...reports 2 errors when used.

1.
        failed to compile rule ws.0: error parsing regexp: unrecognized grouping construct:
        (?P in `\G(?m)(?:(?:--\[(?P<level>=*)\[[\w\W]*?\](?P=level)\]))`

2.
        failed to compile rule funcname.2: error parsing regexp: unrecognized grouping construct:
        (?P in `\G(?m)(?:(?:[^\W\d]\w*)(?=(?:(?:--\[(?P<level>=*)\[[\w\W]*?\](?P=level)\])|(?:--.*$)|(?:\s+))*[.:]))`

## Solution

Because MoonScript is a dialect of Lua, the correct patterns can simply be copied from the Lua lexer.

1. https://github.com/alecthomas/chroma/blob/6ffb4659a4583e296e609c8a8fa82db31159af97/lexers/embedded/lua.xml#L62

2. https://github.com/alecthomas/chroma/blob/6ffb4659a4583e296e609c8a8fa82db31159af97/lexers/embedded/lua.xml#L20

## Changes

This PR replaces the incorrect `NameClass` and `CommentMultiline` token patterns generated by `pygments2chroma_xml.py` for the MoonScript lexer with the correct patterns copied over from the Lua lexer, and adds the new lexer to `lexers/embedded`.