### PR TITLE
correct lexing AS keyword for docker

### DIFF
--- a/lexers/embedded/docker.xml
+++ b/lexers/embedded/docker.xml
@@ -40,9 +40,16 @@
           <using lexer="Bash" />
         </bygroups>
       </rule>
-      <rule pattern="((?:FROM|MAINTAINER|EXPOSE|WORKDIR|USER|STOPSIGNAL)|VOLUME)\b(.*)">
+      <rule
+        pattern="((?:FROM|MAINTAINER|EXPOSE|WORKDIR|USER|STOPSIGNAL)|VOLUME)\b(\s)([\S]*)\b(?:(\s)(AS)\b(\s)([\S]*))?\b"
+      >
         <bygroups>
           <token type="Keyword" />
+          <token type="TextWhitespace" />
+          <token type="LiteralString" />
+          <token type="TextWhitespace" />
+          <token type="Keyword" />
+          <token type="TextWhitespace" />
           <token type="LiteralString" />
         </bygroups>
       </rule>

--- a/lexers/embedded/docker.xml
+++ b/lexers/embedded/docker.xml
@@ -3,10 +3,14 @@
     <name>Docker</name>
     <alias>docker</alias>
     <alias>dockerfile</alias>
+    <alias>containerfile</alias>
     <filename>Dockerfile</filename>
     <filename>Dockerfile.*</filename>
     <filename>*.Dockerfile</filename>
     <filename>*.docker</filename>
+    <filename>Containerfile</filename>
+    <filename>Containerfile.*</filename>
+    <filename>*.Containerfile</filename>
     <mime_type>text/x-dockerfile-config</mime_type>
     <case_insensitive>true</case_insensitive>
   </config>


### PR DESCRIPTION
btw. tinygo can be replace with just go
```Makefile
cmd/chromad/static/wasm_exec.js: $(shell go env GOROOT)/lib/wasm/wasm_exec.js
	install -m644 $< $@

cmd/chromad/static/chroma.wasm: cmd/libchromawasm/main.go
	GOOS=js GOARCH=wasm go build -o $@ $<
```