### PR TITLE
fix: don't emit empty tail tokens

### DIFF
--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -49,6 +49,48 @@ func TestSplitTokensIntoLines(t *testing.T) {
 	}
 	actual := chroma.SplitTokensIntoLines(in)
 	assert.Equal(t, expected, actual)
+
+	in = []chroma.Token{
+		{Value: "func", Type: chroma.KeywordDeclaration},
+		{Value: " ", Type: chroma.TextWhitespace},
+		{Value: "main", Type: chroma.NameFunction},
+		{Value: "()", Type: chroma.Punctuation},
+		{Value: " ", Type: chroma.TextWhitespace},
+		{Value: "{", Type: chroma.Punctuation},
+		{Value: "\n\t", Type: chroma.TextWhitespace},
+		{Value: "println", Type: chroma.NameBuiltin},
+		{Value: "(", Type: chroma.Punctuation},
+		{Value: `"mark this"`, Type: chroma.LiteralString},
+		{Value: ")", Type: chroma.Punctuation},
+		{Value: "\n", Type: chroma.TextWhitespace},
+		{Value: "}", Type: chroma.Punctuation},
+		{Value: "\n", Type: chroma.TextWhitespace},
+	}
+	expected = [][]chroma.Token{
+		{
+			{Type: chroma.KeywordDeclaration, Value: "func"},
+			{Type: chroma.TextWhitespace, Value: " "},
+			{Type: chroma.NameFunction, Value: "main"},
+			{Type: chroma.Punctuation, Value: "()"},
+			{Type: chroma.TextWhitespace, Value: " "},
+			{Type: chroma.Punctuation, Value: "{"},
+			{Type: chroma.TextWhitespace, Value: "\n"},
+		},
+		{
+			{Type: chroma.TextWhitespace, Value: "\t"},
+			{Type: chroma.NameBuiltin, Value: "println"},
+			{Type: chroma.Punctuation, Value: "("},
+			{Type: chroma.LiteralString, Value: `"mark this"`},
+			{Type: chroma.Punctuation, Value: ")"},
+			{Type: chroma.TextWhitespace, Value: "\n"},
+		},
+		{
+			{Type: chroma.Punctuation, Value: "}"},
+			{Type: chroma.TextWhitespace, Value: "\n"},
+		},
+	}
+	actual = chroma.SplitTokensIntoLines(in)
+	assert.Equal(t, expected, actual)
 }
 
 func TestFormatterStyleToCSS(t *testing.T) {

--- a/iterator.go
+++ b/iterator.go
@@ -58,6 +58,7 @@ func Literator(tokens ...Token) Iterator {
 // SplitTokensIntoLines splits tokens containing newlines in two.
 func SplitTokensIntoLines(tokens []Token) (out [][]Token) {
 	var line []Token // nolint: prealloc
+tokenLoop:
 	for _, token := range tokens {
 		for strings.Contains(token.Value, "\n") {
 			parts := strings.SplitAfterN(token.Value, "\n", 2)
@@ -70,6 +71,11 @@ func SplitTokensIntoLines(tokens []Token) (out [][]Token) {
 			line = append(line, clone)
 			out = append(out, line)
 			line = nil
+
+			// If the tail token is empty, don't emit it.
+			if len(token.Value) == 0 {
+				continue tokenLoop
+			}
 		}
 		line = append(line, token)
 	}

--- a/iterator.go
+++ b/iterator.go
@@ -89,5 +89,5 @@ tokenLoop:
 			out = out[:len(out)-1]
 		}
 	}
-	return
+	return out
 }


### PR DESCRIPTION
When tokens are split into lines, tokens that end with a newline are emitted again as an empty token, which is confusing and doesn't have any benefit. This conversion shouldn't emit a empty tail token.

Adds a test.

I noticed this issue by a CI failure for the output of a Go program that was changed because of
d0ad67944442bcb84ff4710fe8dfa8f76ecedc01 and the new output contained a empty whitespace token at the beginning of most lines.