### PR TITLE
`moar` has been renamed to `moor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ for that setup the `chroma` executable can be just symlinked to `~/.lessfilter`.
 
 ## Projects using Chroma
 
-* [`moar`](https://github.com/walles/moar) is a full-blown pager that colorizes
+* [`moor`](https://github.com/walles/moor) is a full-blown pager that colorizes
   its input using Chroma
 * [Hugo](https://gohugo.io/) is a static site generator that [uses Chroma for syntax
   highlighting code examples](https://gohugo.io/content-management/syntax-highlighting/)


### PR DESCRIPTION
Ref: https://github.com/walles/moor/pull/305

The old GitHub project was renamed, and now redirects to the new one, so if you want to verify this is the same project, go to the old project and you will be redirected:

```https://github.com/walles/moar/pull/305```
