### PR TITLE
Add argparse to pygemnts2chroma_xml.py script

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,9 @@ using the included Python 3 script `pygments2chroma_xml.py`. I use something lik
 the following:
 
 ```sh
-python3 _tools/pygments2chroma_xml.py \
+uv run --script _tools/pygments2chroma_xml.py \
   pygments.lexers.jvm.KotlinLexer \
-  > lexers/embedded/kotlin.xml
+  > lexers/embedded/kotlin.xml 
 ```
 
 A list of all lexers available in Pygments can be found in [pygments-lexers.txt](https://github.com/alecthomas/chroma/blob/master/pygments-lexers.txt).

--- a/_tools/pygments2chroma_xml.py
+++ b/_tools/pygments2chroma_xml.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "pygments",
+#     "pystache",
+# ]
+# ///
+import argparse
 import functools
 import importlib
 import re
@@ -168,7 +176,11 @@ class TemplateView(object):
 
 
 def main():
-    package_name, symbol_name = sys.argv[1].rsplit(sep=".", maxsplit=1)
+    parser = argparse.ArgumentParser( prog='pygments2chroma_xml.py', description='Converts pygments RegexLexer classes to chroma xml grammar definitions.')
+    parser.add_argument('lexer_class', type=str, help="The class name of the pygments lexer, like: 'pygments.lexers.jvm.KotlinLexer'.")
+    args = parser.parse_args()
+
+    package_name, symbol_name = args.lexer_class.rsplit(sep=".", maxsplit=1)
 
     package = importlib.import_module(package_name)
 

--- a/_tools/style.py
+++ b/_tools/style.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "pygments",
+#     "pystache",
+# ]
+# ///
 import importlib
 import sys
 


### PR DESCRIPTION
I also adapted the README to use `uv` since this removes an install step (uv resolves and installs dependencies on `uv run`).

We could also debate if we should switch from `KotlinLexer` as an example to some other lexer as there seems to be a bug upstream in pygments where `KotlinLexer.get_tokendefs()` returns a string that is not valid unicode. You can read more about the bug in [this issue](https://github.com/pygments/pygments/issues/2964).

With argparse the error messages are a lot nicer and the script can better explain itself.

```bash
uv run pygments2chroma_xml.py --help                         
usage: pygments2chroma_xml.py [-h] lexer_class

Converts pygments RegexLexer classes to chroma xml grammar definitions.

positional arguments:
  lexer_class  The class name of the pygments lexer, like: 'pygments.lexers.jvm.KotlinLexer'.

options:
  -h, --help   show this help message and exit
  ```