### PR TITLE
more idiomatic iterator use

### DIFF
--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -394,9 +394,6 @@ func format(ctx *kong.Context, w io.Writer, style *chroma.Style, it chroma.Itera
 func check(filename string, it chroma.Iterator) {
 	line, col := 1, 0
 	for token := range it {
-		if token == chroma.EOF {
-			break
-		}
 		if token.Type == chroma.Error {
 			fmt.Printf("%s:%d:%d %q\n", filename, line, col, token.String())
 		}

--- a/coalesce.go
+++ b/coalesce.go
@@ -13,13 +13,10 @@ func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, e
 	return func(yield func(Token) bool) {
 		var prev Token
 		for token := range it {
-			if token == EOF {
-				break
-			}
 			if len(token.Value) == 0 {
 				continue
 			}
-			if prev == EOF {
+			if prev.IsZero() {
 				prev = token
 			} else {
 				if prev.Type == token.Type && len(prev.Value) < 8192 {
@@ -32,7 +29,7 @@ func (d *coalescer) Tokenise(options *TokeniseOptions, text string) (Iterator, e
 				}
 			}
 		}
-		if prev != EOF {
+		if !prev.IsZero() {
 			yield(prev)
 		}
 	}, nil

--- a/delegate.go
+++ b/delegate.go
@@ -71,12 +71,12 @@ func (d *delegatingLexer) Tokenise(options *TokeniseOptions, text string) (Itera
 	var last Token
 	for _, t := range tokens {
 		if t.Type == Other {
-			if last != EOF && insert != nil && last.Type != Other {
+			if !last.IsZero() && insert != nil && last.Type != Other {
 				insert.end = offset
 			}
 			others.WriteString(t.Value)
 		} else {
-			if last == EOF || last.Type == Other {
+			if last.IsZero() || last.Type == Other {
 				insert = &insertion{start: offset}
 				insertions = append(insertions, insert)
 			}
@@ -97,64 +97,71 @@ func (d *delegatingLexer) Tokenise(options *TokeniseOptions, text string) (Itera
 	}
 
 	// Interleave the two sets of tokens.
-	var out []Token
-	offset = 0 // Offset into text.
-	tokenIndex := 0
-	nextToken := func() Token {
-		if tokenIndex >= len(rootTokens) {
-			return EOF
-		}
-		t := rootTokens[tokenIndex]
-		tokenIndex++
-		return t
-	}
-	insertionIndex := 0
-	nextInsertion := func() *insertion {
-		if insertionIndex >= len(insertions) {
-			return nil
-		}
-		i := insertions[insertionIndex]
-		insertionIndex++
-		return i
-	}
-	t := nextToken()
-	i := nextInsertion()
-	for t != EOF || i != nil {
-		// fmt.Printf("%d->%d:%q   %d->%d:%q\n", offset, offset+len(t.Value), t.Value, i.start, i.end, Stringify(i.tokens...))
-		if t == EOF || (i != nil && i.start < offset+len(t.Value)) {
-			var l Token
-			l, t = splitToken(t, i.start-offset)
-			if l != EOF {
-				out = append(out, l)
-				offset += len(l.Value)
+	return func(yield func(Token) bool) {
+		offset := 0 // Offset into text.
+		tokenIndex := 0
+		nextToken := func() Token {
+			if tokenIndex >= len(rootTokens) {
+				return Token{}
 			}
-			out = append(out, i.tokens...)
-			offset += i.end - i.start
-			if t == EOF {
+			t := rootTokens[tokenIndex]
+			tokenIndex++
+			return t
+		}
+		insertionIndex := 0
+		nextInsertion := func() *insertion {
+			if insertionIndex >= len(insertions) {
+				return nil
+			}
+			i := insertions[insertionIndex]
+			insertionIndex++
+			return i
+		}
+		t := nextToken()
+		i := nextInsertion()
+		for !t.IsZero() || i != nil {
+			// fmt.Printf("%d->%d:%q   %d->%d:%q\n", offset, offset+len(t.Value), t.Value, i.start, i.end, Stringify(i.tokens...))
+			if t.IsZero() || (i != nil && i.start < offset+len(t.Value)) {
+				var l Token
+				l, t = splitToken(t, i.start-offset)
+				if !l.IsZero() {
+					if !yield(l) {
+						return
+					}
+					offset += len(l.Value)
+				}
+				for _, tok := range i.tokens {
+					if !yield(tok) {
+						return
+					}
+				}
+				offset += i.end - i.start
+				if t.IsZero() {
+					t = nextToken()
+				}
+				i = nextInsertion()
+			} else {
+				if !yield(t) {
+					return
+				}
+				offset += len(t.Value)
 				t = nextToken()
 			}
-			i = nextInsertion()
-		} else {
-			out = append(out, t)
-			offset += len(t.Value)
-			t = nextToken()
 		}
-	}
-	return Literator(out...), nil
+	}, nil
 }
 
 func splitToken(t Token, offset int) (l Token, r Token) {
-	if t == EOF {
-		return EOF, EOF
+	if t.IsZero() {
+		return t, t
 	}
 	if offset == 0 {
-		return EOF, t
+		return Token{}, t
 	}
 	if offset == len(t.Value) {
-		return t, EOF
+		return t, Token{}
 	}
-	l = t.Clone()
-	r = t.Clone()
+	l, r = t, t
 	l.Value = l.Value[:offset]
 	r.Value = r.Value[offset:]
 	return

--- a/delegate_test.go
+++ b/delegate_test.go
@@ -1,6 +1,7 @@
 package chroma
 
 import (
+	"slices"
 	"testing"
 
 	assert "github.com/alecthomas/assert/v2"
@@ -104,7 +105,7 @@ func TestDelegate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			it, err := delegate.Tokenise(nil, test.source)
 			assert.NoError(t, err)
-			actual := it.Tokens()
+			actual := slices.Collect(it)
 			assert.Equal(t, test.expected, actual)
 		})
 	}

--- a/formatters/api.go
+++ b/formatters/api.go
@@ -13,9 +13,6 @@ var (
 	// NoOp formatter.
 	NoOp = Register("noop", chroma.FormatterFunc(func(w io.Writer, s *chroma.Style, iterator chroma.Iterator) error {
 		for t := range iterator {
-			if t == chroma.EOF {
-				break
-			}
 			if _, err := io.WriteString(w, t.Value); err != nil {
 				return err
 			}

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
@@ -47,7 +48,9 @@ func TestSplitTokensIntoLines(t *testing.T) {
 			{Type: chroma.NameKeyword, Value: "what?\n"},
 		},
 	}
-	actual := chroma.SplitTokensIntoLines(in)
+	actual := slices.Collect(chroma.SplitTokensIntoLines(slices.Values(in)))
+	t.Logf("got[%d]: %q", len(actual), actual)
+	t.Logf("want[%d]: %q", len(expected), expected)
 	assert.Equal(t, expected, actual)
 
 	in = []chroma.Token{
@@ -89,7 +92,7 @@ func TestSplitTokensIntoLines(t *testing.T) {
 			{Type: chroma.TextWhitespace, Value: "\n"},
 		},
 	}
-	actual = chroma.SplitTokensIntoLines(in)
+	actual = slices.Collect(chroma.SplitTokensIntoLines(slices.Values(in)))
 	assert.Equal(t, expected, actual)
 }
 

--- a/formatters/json.go
+++ b/formatters/json.go
@@ -15,9 +15,6 @@ var JSON = Register("json", chroma.FormatterFunc(func(w io.Writer, s *chroma.Sty
 	}
 	i := 0
 	for t := range it {
-		if t == chroma.EOF {
-			break
-		}
 		if i > 0 {
 			if _, err := fmt.Fprintln(w, ","); err != nil {
 				return err

--- a/formatters/svg/svg.go
+++ b/formatters/svg/svg.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
@@ -62,7 +63,7 @@ type Formatter struct {
 }
 
 func (f *Formatter) Format(w io.Writer, style *chroma.Style, iterator chroma.Iterator) (err error) {
-	f.writeSVG(w, style, iterator.Tokens())
+	f.writeSVG(w, style, iterator)
 	return err
 }
 
@@ -80,9 +81,9 @@ func escapeString(s string) string {
 	return svgEscaper.Replace(s)
 }
 
-func (f *Formatter) writeSVG(w io.Writer, style *chroma.Style, tokens []chroma.Token) { // nolint: gocyclo
+func (f *Formatter) writeSVG(w io.Writer, style *chroma.Style, tokens chroma.Iterator) { // nolint: gocyclo
 	svgStyles := f.styleToSVG(style)
-	lines := chroma.SplitTokensIntoLines(tokens)
+	lines := slices.Collect(chroma.SplitTokensIntoLines(tokens))
 
 	fmt.Fprint(w, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
 	fmt.Fprint(w, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.0//EN\" \"http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd\">\n")

--- a/formatters/tokens.go
+++ b/formatters/tokens.go
@@ -10,9 +10,6 @@ import (
 // Tokens formatter outputs the raw token structures.
 var Tokens = Register("tokens", chroma.FormatterFunc(func(w io.Writer, s *chroma.Style, it chroma.Iterator) error {
 	for t := range it {
-		if t == chroma.EOF {
-			break
-		}
 		if _, err := fmt.Fprintln(w, t.GoString()); err != nil {
 			return err
 		}

--- a/formatters/tty_indexed.go
+++ b/formatters/tty_indexed.go
@@ -240,9 +240,6 @@ type indexedTTYFormatter struct {
 func (c *indexedTTYFormatter) Format(w io.Writer, style *chroma.Style, it chroma.Iterator) (err error) {
 	theme := styleToEscapeSequence(c.table, style)
 	for token := range it {
-		if token == chroma.EOF {
-			break
-		}
 		clr, ok := theme[token.Type]
 
 		// This search mimics how styles.Get() is used in tty_truecolour.go.

--- a/formatters/tty_truecolour.go
+++ b/formatters/tty_truecolour.go
@@ -47,9 +47,6 @@ func writeToken(w io.Writer, formatting string, text string) {
 func trueColourFormatter(w io.Writer, style *chroma.Style, it chroma.Iterator) error {
 	style = clearBackground(style)
 	for token := range it {
-		if token == chroma.EOF {
-			break
-		}
 		entry := style.Get(token.Type)
 		if entry.IsZero() {
 			fmt.Fprint(w, token.Value)

--- a/lexer.go
+++ b/lexer.go
@@ -85,16 +85,11 @@ type Token struct {
 	Value string    `json:"value"`
 }
 
-func (t *Token) String() string   { return t.Value }
-func (t *Token) GoString() string { return fmt.Sprintf("&Token{%s, %q}", t.Type, t.Value) }
-
-// Clone returns a clone of the Token.
-func (t *Token) Clone() Token {
-	return *t
+func (t Token) String() string   { return t.Value }
+func (t Token) GoString() string { return fmt.Sprintf("Token{%s, %q}", t.Type, t.Value) }
+func (t Token) IsZero() bool {
+	return t == Token{}
 }
-
-// EOF is returned by lexers at the end of input.
-var EOF Token
 
 // TokeniseOptions contains options for tokenisers.
 type TokeniseOptions struct {

--- a/lexers/http.go
+++ b/lexers/http.go
@@ -80,10 +80,6 @@ func (d *httpBodyContentTyper) Tokenise(options *TokeniseOptions, text string) (
 		var subIterator Iterator
 
 		for token := range it {
-			if token == EOF {
-				break
-			}
-
 			switch {
 			case token.Type == Name && strings.ToLower(token.Value) == "content-type":
 				{
@@ -120,9 +116,6 @@ func (d *httpBodyContentTyper) Tokenise(options *TokeniseOptions, text string) (
 						}
 						// Emit tokens from the sub-iterator
 						for st := range subIterator {
-							if st == EOF {
-								break
-							}
 							if !yield(st) {
 								return
 							}

--- a/lexers/lexer_benchmark_test.go
+++ b/lexers/lexer_benchmark_test.go
@@ -5,7 +5,6 @@ import (
 
 	assert "github.com/alecthomas/assert/v2"
 
-	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
 )
 
@@ -212,10 +211,7 @@ func Benchmark(b *testing.B) {
 	for range b.N {
 		it, err := lexers.GlobalLexerRegistry.Get("Java").Tokenise(nil, lexerBenchSource)
 		assert.NoError(b, err)
-		for t := range it {
-			if t == chroma.EOF {
-				break
-			}
+		for range it {
 		}
 	}
 }

--- a/mutators_test.go
+++ b/mutators_test.go
@@ -1,6 +1,7 @@
 package chroma
 
 import (
+	"slices"
 	"testing"
 
 	assert "github.com/alecthomas/assert/v2"
@@ -53,5 +54,5 @@ func TestCombine(t *testing.T) {
 	it, err := l.Tokenise(nil, "hello world")
 	assert.NoError(t, err)
 	expected := []Token{{String, `hello`}, {Whitespace, ` `}, {Name, `world`}}
-	assert.Equal(t, expected, it.Tokens())
+	assert.Equal(t, expected, slices.Collect(it))
 }

--- a/regexp.go
+++ b/regexp.go
@@ -41,9 +41,6 @@ func Tokenise(lexer Lexer, options *TokeniseOptions, text string) ([]Token, erro
 		return nil, err
 	}
 	for t := range it {
-		if t == EOF {
-			break
-		}
 		out = append(out, t)
 	}
 	return out, nil
@@ -219,7 +216,7 @@ func (l *LexerState) Iterator(yield func(Token) bool) { // nolint: gocognit
 			if t.Type == Ignore {
 				continue
 			}
-			if t == EOF {
+			if t.IsZero() {
 				l.tokenStack = l.tokenStack[:n]
 				continue
 			}
@@ -311,7 +308,7 @@ func (l *LexerState) Iterator(yield func(Token) bool) { // nolint: gocognit
 		if t.Type == Ignore {
 			continue
 		}
-		if t == EOF {
+		if t.IsZero() {
 			l.tokenStack = l.tokenStack[:n]
 			continue
 		}

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -1,6 +1,7 @@
 package chroma
 
 import (
+	"slices"
 	"testing"
 
 	assert "github.com/alecthomas/assert/v2"
@@ -22,7 +23,7 @@ func TestNewlineAtEndOfFile(t *testing.T) {
 	}))
 	it, err := l.Tokenise(nil, `hello`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{Keyword, "hello"}, {Whitespace, "\n"}}, it.Tokens())
+	assert.Equal(t, []Token{{Keyword, "hello"}, {Whitespace, "\n"}}, slices.Collect(it))
 
 	l = Coalesce(mustNewLexer(t, nil, Rules{ // nolint: forbidigo
 		"root": {
@@ -31,7 +32,7 @@ func TestNewlineAtEndOfFile(t *testing.T) {
 	}))
 	it, err = l.Tokenise(nil, `hello`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{Error, "hello"}}, it.Tokens())
+	assert.Equal(t, []Token{{Error, "hello"}}, slices.Collect(it))
 }
 
 func TestMatchingAtStart(t *testing.T) {
@@ -49,7 +50,7 @@ func TestMatchingAtStart(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		[]Token{{Punctuation, "-"}, {NameEntity, "module"}, {Whitespace, " "}, {Operator, "->"}},
-		it.Tokens())
+		slices.Collect(it))
 }
 
 func TestEnsureLFOption(t *testing.T) {
@@ -68,7 +69,7 @@ func TestEnsureLFOption(t *testing.T) {
 		{Whitespace, "\n"},
 		{Keyword, "world"},
 		{Whitespace, "\n"},
-	}, it.Tokens())
+	}, slices.Collect(it))
 
 	l = Coalesce(mustNewLexer(t, nil, Rules{ // nolint: forbidigo
 		"root": {
@@ -85,7 +86,7 @@ func TestEnsureLFOption(t *testing.T) {
 		{Whitespace, "\r\n"},
 		{Keyword, "world"},
 		{Whitespace, "\r"},
-	}, it.Tokens())
+	}, slices.Collect(it))
 }
 
 func TestEnsureLFFunc(t *testing.T) {
@@ -124,7 +125,7 @@ func TestByGroupNames(t *testing.T) {
 	}))
 	it, err := l.Tokenise(nil, `abc=123`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{String, `abc`}, {Operator, `=`}, {String, `123`}}, it.Tokens())
+	assert.Equal(t, []Token{{String, `abc`}, {Operator, `=`}, {String, `123`}}, slices.Collect(it))
 
 	l = Coalesce(mustNewLexer(t, nil, Rules{ // nolint: forbidigo
 		"root": {
@@ -140,7 +141,7 @@ func TestByGroupNames(t *testing.T) {
 	}))
 	it, err = l.Tokenise(nil, `abc=123`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{String, `abc`}, {Error, `=`}, {String, `123`}}, it.Tokens())
+	assert.Equal(t, []Token{{String, `abc`}, {Error, `=`}, {String, `123`}}, slices.Collect(it))
 
 	l = Coalesce(mustNewLexer(t, nil, Rules{ // nolint: forbidigo
 		"root": {
@@ -156,7 +157,7 @@ func TestByGroupNames(t *testing.T) {
 	}))
 	it, err = l.Tokenise(nil, `abc=123`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{String, `abc123`}}, it.Tokens())
+	assert.Equal(t, []Token{{String, `abc123`}}, slices.Collect(it))
 
 	l = Coalesce(mustNewLexer(t, nil, Rules{ // nolint: forbidigo
 		"root": {
@@ -173,7 +174,7 @@ func TestByGroupNames(t *testing.T) {
 	}))
 	it, err = l.Tokenise(nil, `abc=123`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{String, `abc`}, {Error, `=`}, {String, `123`}}, it.Tokens())
+	assert.Equal(t, []Token{{String, `abc`}, {Error, `=`}, {String, `123`}}, slices.Collect(it))
 
 	l = Coalesce(mustNewLexer(t, nil, Rules{ // nolint: forbidigo
 		"root": {
@@ -190,7 +191,7 @@ func TestByGroupNames(t *testing.T) {
 	}))
 	it, err = l.Tokenise(nil, `abc=123`)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{Error, `abc=123`}}, it.Tokens())
+	assert.Equal(t, []Token{{Error, `abc=123`}}, slices.Collect(it))
 }
 
 func TestIgnoreToken(t *testing.T) {
@@ -201,5 +202,5 @@ func TestIgnoreToken(t *testing.T) {
 	}))
 	it, err := l.Tokenise(nil, `  hello  `)
 	assert.NoError(t, err)
-	assert.Equal(t, []Token{{Keyword, "hello"}, {TextWhitespace, "\n"}}, it.Tokens())
+	assert.Equal(t, []Token{{Keyword, "hello"}, {TextWhitespace, "\n"}}, slices.Collect(it))
 }

--- a/remap.go
+++ b/remap.go
@@ -35,9 +35,6 @@ func (r *remappingLexer) Tokenise(options *TokeniseOptions, text string) (Iterat
 	}
 	return func(yield func(Token) bool) {
 		for t := range it {
-			if t == EOF {
-				break
-			}
 			mapped := r.mapper(t)
 			for _, mt := range mapped {
 				if !yield(mt) {

--- a/remap_test.go
+++ b/remap_test.go
@@ -1,6 +1,7 @@
 package chroma
 
 import (
+	"slices"
 	"testing"
 
 	assert "github.com/alecthomas/assert/v2"
@@ -24,6 +25,6 @@ func TestRemappingLexer(t *testing.T) {
 		{TextWhitespace, " "}, {Name, "print"}, {TextWhitespace, " "}, {Keyword, "else"},
 		{TextWhitespace, " "}, {Name, "end"},
 	}
-	actual := it.Tokens()
+	actual := slices.Collect(it)
 	assert.Equal(t, expected, actual)
 }


### PR DESCRIPTION
NOTE: this PR is targeted at the stdlib-iterator branch as a potential improved v2 API, _not_ current tip.

nerdsnipe alert: I'm still in relatively early phases of exploring iterator idiom, so couldn't resist having a go at simplifying SplitTokensIntoLines which is now fully streaming (even though none of the call sites look like they can take advantage of that currently). 

I removed the `EOF` variable, replacing it with an `IsZero` method which can be used to check if a `Token` is valid or not. (I don't see anywhere that seems to rely on yielding an EOF value: all the tests pass.)

Aside: one convention from the stdlib I realise I've absorbed but never actually expressed: iterators are generally named in Go as "sequences", so perhaps use `chroma.Seq` rather than `chroma.Iterator` (also has the advantage that it's shorter), or just inline `iter.Seq[chroma.Token]` everywhere - it's not _that_ long and it's super-clear - and remove `Iterator` entirely.
