### PR TITLE
tango: Don't underline whitespace

### DIFF
--- a/styles/tango.xml
+++ b/styles/tango.xml
@@ -68,5 +68,5 @@
   <entry type="GenericSubheading" style="bold #800080"/>
   <entry type="GenericTraceback" style="bold #a40000"/>
   <entry type="GenericUnderline" style="underline"/>
-  <entry type="TextWhitespace" style="underline #f8f8f8"/>
+  <entry type="TextWhitespace" style="#f8f8f8"/>
 </style>


### PR DESCRIPTION
This makes Chroma's tango whitespaces match the original:

https://github.com/pygments/pygments/blob/0328cfaf1d953b3a0c7eb0ec0efd363deb2f9d51/pygments/styles/tango.py#L60

The underline looks like a rendering bug when marking text.