### PR TITLE
fix(styles): use kebab-case for style name in Aura Theme variants

### DIFF
--- a/styles/aura-theme-dark-soft.xml
+++ b/styles/aura-theme-dark-soft.xml
@@ -1,10 +1,10 @@
 <!--
 # Aura Theme Dark Soft > Color scheme for Chroma syntax highlighter
 # Repository: https://github.com/daltonmenezes/aura-theme
-# Theme version: 1.0.0
+# Theme version: 1.0.1
 -->
 
-<style name="Aura Theme Dark Soft">
+<style name="aura-theme-dark-soft">
   <!-- Base -->
   <entry type="Background" style="bg:#15141b #bdbdbd"/>
   <entry type="CodeLine" style="#bdbdbd"/>

--- a/styles/aura-theme-dark.xml
+++ b/styles/aura-theme-dark.xml
@@ -1,10 +1,10 @@
 <!--
 # Aura Theme Dark > Color scheme for Chroma syntax highlighter
 # Repository: https://github.com/daltonmenezes/aura-theme
-# Theme version: 1.0.0
+# Theme version: 1.0.1
 -->
 
-<style name="Aura Theme Dark">
+<style name="aura-theme-dark">
   <!-- Base -->
   <entry type="Background" style="bg:#15141b #edecee"/>
   <entry type="CodeLine" style="#edecee"/>


### PR DESCRIPTION
### Description

Fixes #1182 by correcting the style name to follow existing kebab-case convention