### PR TITLE
fix: no text auto-sizing on webkit

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -528,6 +528,7 @@ func (f *Formatter) styleToCSS(style *chroma.Style) map[chroma.TokenType]string 
 	}
 	classes[chroma.Background] += `;` + f.tabWidthStyle()
 	classes[chroma.PreWrapper] += classes[chroma.Background]
+	classes[chroma.PreWrapper] += ` -webkit-text-size-adjust: none;`
 	// Make PreWrapper a grid to show highlight style with full width.
 	if len(f.highlightRanges) > 0 && f.customCSS[chroma.PreWrapper] == `` {
 		classes[chroma.PreWrapper] += `display: grid;`


### PR DESCRIPTION
That ensures that no line is displayed with a bigger font-size due to its length.

see https://bugs.webkit.org/show_bug.cgi?id=304640

Fixes #1101 