### PR TITLE
Add APKBUILD as filename to Bash lexer

### DIFF
--- a/lexers/embedded/bash.xml
+++ b/lexers/embedded/bash.xml
@@ -23,6 +23,7 @@
     <filename>bash_*</filename>
     <filename>zshrc</filename>
     <filename>.zshrc</filename>
+    <filename>APKBUILD</filename>
     <filename>PKGBUILD</filename>
     <mime_type>application/x-sh</mime_type>
     <mime_type>application/x-shellscript</mime_type>


### PR DESCRIPTION
Fixes https://codeberg.org/forgejo/forgejo/issues/10650