### PR TITLE
Add `.env.*` pattern to bash lexer

### DIFF
--- a/lexers/embedded/bash.xml
+++ b/lexers/embedded/bash.xml
@@ -12,8 +12,8 @@
     <filename>*.ebuild</filename>
     <filename>*.eclass</filename>
     <filename>.env</filename>
-    <filename>*.env</filename>
     <filename>.env.*</filename>
+    <filename>*.env</filename>
     <filename>*.exheres-0</filename>
     <filename>*.exlib</filename>
     <filename>*.zsh</filename>


### PR DESCRIPTION
Reference: https://vite.dev/guide/env-and-mode#env-files