### PR TITLE
Import Gettext lexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ translators for Pygments lexers and styles.
 |   D    | D, Dart, Dax, Desktop file, Diff, Django/Jinja, dns, Docker, DTD, Dylan
 |   E    | EBNF, Elixir, Elm, EmacsLisp, Erlang
 |   F    | Factor, Fennel, Fish, Forth, Fortran, FortranFixed, FSharp
-|   G    | GAS, GDScript, GDScript3, Gemtext, Genshi, Genshi HTML, Genshi Text, Gherkin, Gleam, GLSL, Gnuplot, Go, Go HTML Template, Go Template, Go Text Template, GraphQL, Groff, Groovy
+|   G    | GAS, GDScript, GDScript3, Gemtext, Genshi, Genshi HTML, Genshi Text, Gettext, Gherkin, Gleam, GLSL, Gnuplot, Go, Go HTML Template, Go Template, Go Text Template, GraphQL, Groff, Groovy
 |   H    | Handlebars, Hare, Haskell, Haxe, HCL, Hexdump, HLB, HLSL, HolyC, HTML, HTTP, Hy
 |   I    | Idris, Igor, INI, Io, ISCdhcpd
 |   J    | J, Janet, Java, JavaScript, JSON, JSONata, Jsonnet, Julia, Jungle

--- a/lexers/embedded/gettext.xml
+++ b/lexers/embedded/gettext.xml
@@ -1,0 +1,24 @@
+
+<lexer>
+  <config>
+    <name>Gettext</name>
+    <alias>pot</alias>
+    <alias>po</alias>
+    <filename>*.pot</filename>
+    <filename>*.po</filename>
+    <mime_type>application/x-gettext</mime_type>
+    <mime_type>text/x-gettext</mime_type>
+    <mime_type>text/gettext</mime_type>
+  </config>
+  <rules>
+    <state name="root">
+      <rule pattern="^#,\s.*?$"><token type="KeywordType"/></rule>
+      <rule pattern="^#:\s.*?$"><token type="KeywordDeclaration"/></rule>
+      <rule pattern="^(#|#\.\s|#\|\s|#~\s|#\s).*$"><token type="CommentSingle"/></rule>
+      <rule pattern="^(&quot;)([A-Za-z-]+:)(.*&quot;)$"><bygroups><token type="LiteralString"/><token type="NameProperty"/><token type="LiteralString"/></bygroups></rule>
+      <rule pattern="^&quot;.*&quot;$"><token type="LiteralString"/></rule>
+      <rule pattern="^(msgid|msgid_plural|msgstr|msgctxt)(\s+)(&quot;.*&quot;)$"><bygroups><token type="NameVariable"/><token type="Text"/><token type="LiteralString"/></bygroups></rule>
+      <rule pattern="^(msgstr\[)(\d)(\])(\s+)(&quot;.*&quot;)$"><bygroups><token type="NameVariable"/><token type="LiteralNumberInteger"/><token type="NameVariable"/><token type="Text"/><token type="LiteralString"/></bygroups></rule>
+    </state>
+  </rules>
+</lexer>

--- a/lexers/testdata/gettext.actual
+++ b/lexers/testdata/gettext.actual
@@ -1,0 +1,5 @@
+#. TRANSLATORS: %s contains the user's name as specified in Preferences
+#, c-format
+#: src/name.c:36
+msgid "My name is %s.\n"
+msgstr ""

--- a/lexers/testdata/gettext.expected
+++ b/lexers/testdata/gettext.expected
@@ -1,0 +1,16 @@
+[
+  {"type":"CommentSingle","value":"#. TRANSLATORS: %s contains the user's name as specified in Preferences"},
+  {"type":"Error","value":"\n"},
+  {"type":"KeywordType","value":"#, c-format"},
+  {"type":"Error","value":"\n"},
+  {"type":"KeywordDeclaration","value":"#: src/name.c:36"},
+  {"type":"Error","value":"\n"},
+  {"type":"NameVariable","value":"msgid"},
+  {"type":"Text","value":" "},
+  {"type":"LiteralString","value":"\"My name is %s.\\n\""},
+  {"type":"Error","value":"\n"},
+  {"type":"NameVariable","value":"msgstr"},
+  {"type":"Text","value":" "},
+  {"type":"LiteralString","value":"\"\""},
+  {"type":"Error","value":"\n"}
+]


### PR DESCRIPTION
This PR imports the Gettext lexer (`pygments.lexers.textfmts.GettextLexer`) from Pygments.