### PR TITLE
Fix Readme table generation

### DIFF
--- a/table.py
+++ b/table.py
@@ -5,7 +5,7 @@ from subprocess import check_output
 
 README_FILE = "README.md"
 
-lines = check_output(["chroma", "--list"]).decode("utf-8").splitlines()
+lines = check_output(["go", "run", ".", "--list"], cwd="cmd/chroma").decode("utf-8").splitlines()
 lines = [line.strip() for line in lines if line.startswith("  ") and not line.startswith("   ")]
 lines = sorted(lines, key=lambda l: l.lower())
 


### PR DESCRIPTION
Currently the `chroma` binary needs to be in` PATH` for this script to work. This is a bit weird while developing. With this PR the script now runs Chroma directly from source.