### PR TITLE
Add `meson.options` as filename for Meson

### DIFF
--- a/lexers/embedded/meson.xml
+++ b/lexers/embedded/meson.xml
@@ -4,6 +4,7 @@
     <alias>meson</alias>
     <alias>meson.build</alias>
     <filename>meson.build</filename>
+    <filename>meson.options</filename>
     <filename>meson_options.txt</filename>
     <mime_type>text/x-meson</mime_type>
   </config>


### PR DESCRIPTION
Meson has replaced `meson_options.txt` with `meson.options`. See [the documentation](https://mesonbuild.com/Build-options.html#build-options).