### PR TITLE
Add `.qrc` as extension for XML

### DIFF
--- a/lexers/embedded/xml.xml
+++ b/lexers/embedded/xml.xml
@@ -10,6 +10,7 @@
     <filename>*.wsdl</filename>
     <filename>*.wsf</filename>
     <filename>*.svg</filename>
+    <filename>*.qrc</filename>
     <filename>*.csproj</filename>
     <filename>*.vcxproj</filename>
     <filename>*.fsproj</filename>


### PR DESCRIPTION
This extension [is used by Qt](https://doc.qt.io/qt-6/resources.html#the-qt-resource-compiler-rcc)