### PR TITLE
Update the PHP lexer

### DIFF
--- a/lexers/embedded/php.xml
+++ b/lexers/embedded/php.xml
@@ -54,7 +54,7 @@
       <rule pattern="\\([nrt&#34;$\\]|[0-7]{1,3}|x[0-9a-f]{1,2})">
         <token type="LiteralStringEscape"/>
       </rule>
-      <rule pattern="\$(?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*(\[\S+?\]|-&gt;(?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*)?">
+      <rule pattern="\$(?:[_a-z]|[^\x00-\x7f])(?:\w|[^\x00-\x7f])*(\[\S+?\]|-&gt;(?:[_a-z]|[^\x00-\x7f])(?:\w|[^\x00-\x7f])*)?">
         <token type="LiteralStringInterpol"/>
       </rule>
       <rule pattern="(\{\$\{)(.*?)(\}\})">
@@ -82,12 +82,46 @@
         <token type="LiteralStringDouble"/>
       </rule>
     </state>
+    <state name="variablevariable">
+      <rule pattern="\}">
+        <token type="NameVariable"/>
+        <pop depth="1"/>
+      </rule>
+      <rule>
+        <include state="root"/>
+      </rule>
+    </state>
+    <state name="attribute">
+      <rule pattern="\]">
+        <token type="Punctuation"/>
+        <pop depth="1"/>
+      </rule>
+      <rule pattern="\(">
+        <token type="Punctuation"/>
+        <push state="attributeparams"/>
+      </rule>
+      <rule pattern="(?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*">
+        <token type="NameDecorator"/>
+      </rule>
+      <rule>
+        <include state="root"/>
+      </rule>
+    </state>
+    <state name="attributeparams">
+      <rule pattern="\)">
+        <token type="Punctuation"/>
+        <pop depth="1"/>
+      </rule>
+      <rule>
+        <include state="root"/>
+      </rule>
+    </state>
     <state name="root">
       <rule pattern="\?&gt;">
         <token type="CommentPreproc"/>
         <pop depth="1"/>
       </rule>
-      <rule pattern="(&lt;&lt;&lt;)([\&#39;&#34;]?)((?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*)(\2\n.*?\n\s*)(\3)(;?)(\n)">
+      <rule pattern="(&lt;&lt;&lt;)([\&#39;&#34;]?)((?:[_a-z]|[^\x00-\x7f])(?:\w|[^\x00-\x7f])*)(\2\n.*?\n\s*)(\3)(;?)(\n)">
         <bygroups>
           <token type="LiteralString"/>
           <token type="LiteralString"/>
@@ -100,6 +134,10 @@
       </rule>
       <rule pattern="\s+">
         <token type="Text"/>
+      </rule>
+      <rule pattern="#\[">
+        <token type="Punctuation"/>
+        <push state="attribute"/>
       </rule>
       <rule pattern="#.*?\n">
         <token type="CommentSingle"/>
@@ -116,7 +154,7 @@
       <rule pattern="/\*.*?\*/">
         <token type="CommentMultiline"/>
       </rule>
-      <rule pattern="(-&gt;|::)(\s*)((?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*)">
+      <rule pattern="(-&gt;|::)(\s*)((?:[_a-z]|[^\x00-\x7f])(?:\w|[^\x00-\x7f])*)">
         <bygroups>
           <token type="Operator"/>
           <token type="Text"/>
@@ -131,6 +169,13 @@
       </rule>
       <rule pattern="[\[\]{}();,]+">
         <token type="Punctuation"/>
+      </rule>
+      <rule pattern="(new)(\s+)(class)\b">
+        <bygroups>
+          <token type="Keyword"/>
+          <token type="Text"/>
+          <token type="Keyword"/>
+        </bygroups>
       </rule>
       <rule pattern="(class)(\s+)">
         <bygroups>
@@ -161,7 +206,7 @@
           <token type="NameConstant"/>
         </bygroups>
       </rule>
-      <rule pattern="(and|E_PARSE|old_function|E_ERROR|or|as|E_WARNING|parent|eval|PHP_OS|break|exit|case|extends|PHP_VERSION|cfunction|FALSE|print|for|require|continue|foreach|require_once|declare|return|default|static|do|switch|die|stdClass|echo|else|TRUE|elseif|var|empty|if|xor|enddeclare|include|virtual|endfor|include_once|while|endforeach|global|endif|list|endswitch|new|endwhile|not|array|E_ALL|NULL|final|php_user_filter|interface|implements|public|private|protected|abstract|clone|try|catch|throw|this|use|namespace|trait|yield|finally)\b">
+      <rule pattern="(and|E_PARSE|old_function|E_ERROR|or|as|E_WARNING|parent|eval|PHP_OS|break|exit|case|extends|PHP_VERSION|cfunction|FALSE|print|for|require|continue|foreach|require_once|declare|return|default|static|do|switch|die|stdClass|echo|else|TRUE|elseif|var|empty|if|xor|enddeclare|include|virtual|endfor|include_once|while|endforeach|global|endif|list|endswitch|new|endwhile|not|array|E_ALL|NULL|final|php_user_filter|interface|implements|public|private|protected|abstract|clone|try|catch|throw|this|use|namespace|trait|yield|finally|match)\b">
         <token type="Keyword"/>
       </rule>
       <rule pattern="(true|false|null)\b">
@@ -170,8 +215,9 @@
       <rule>
         <include state="magicconstants"/>
       </rule>
-      <rule pattern="\$\{\$+(?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*\}">
+      <rule pattern="\$\{">
         <token type="NameVariable"/>
+        <push state="variablevariable"/>
       </rule>
       <rule pattern="\$+(?:[\\_a-z]|[^\x00-\x7f])(?:[\\\w]|[^\x00-\x7f])*">
         <token type="NameVariable"/>
@@ -185,7 +231,7 @@
       <rule pattern="\d+e[+-]?[0-9]+">
         <token type="LiteralNumberFloat"/>
       </rule>
-      <rule pattern="0[0-7]+">
+      <rule pattern="0o?[0-7_]+">
         <token type="LiteralNumberOct"/>
       </rule>
       <rule pattern="0x[a-f0-9_]+">
@@ -194,7 +240,7 @@
       <rule pattern="\d[\d_]*">
         <token type="LiteralNumberInteger"/>
       </rule>
-      <rule pattern="0b[01]+">
+      <rule pattern="0b[01_]+">
         <token type="LiteralNumberBin"/>
       </rule>
       <rule pattern="&#39;([^&#39;\\]*(?:\\.[^&#39;\\]*)*)&#39;">


### PR DESCRIPTION
This updates the PHP lexer from Pygments. Namely, it adds support for [attributes](https://www.php.net/manual/en/language.attributes.overview.php). I've preserved the `_` handling in numbers which is not available in Pygments and I've also improved it a bit.