### PR TITLE
Fix error handling in `needRules()`

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -308,6 +308,7 @@ type RegexLexer struct {
 	rules          map[string][]*CompiledRule
 	fetchRulesFunc func() (Rules, error)
 	compileOnce    sync.Once
+	compileError   error
 }
 
 func (r *RegexLexer) String() string {
@@ -446,8 +447,11 @@ func (r *RegexLexer) needRules() error {
 	var err error
 	if r.fetchRulesFunc != nil {
 		r.compileOnce.Do(func() {
-			err = r.fetchRules()
+			r.compileError = r.fetchRules()
 		})
+		if r.compileError != nil {
+			return r.compileError
+		}
 	}
 	if err := r.maybeCompile(); err != nil {
 		return err


### PR DESCRIPTION
I discovered a little bug while trying to import a Pygments lexer: `needRules()` calls `fetchRules()` inside `compileOnce`. This means that `fetchRules()` is only called the first time `needRules()` is called. So if the `needRules()` is called by `Tokenise()` the error will only be handled the first time. Any call to `Tokenise()` after that will cause a panic, as no rules are loaded. To fix that, we need to store the error in the struct.

If you want to test it, you can try this invalid lexer in `chromad`:
```xml
<lexer>
  <config>
    <name>Test</name>
  </config>
  <rules>
  </rules>
</lexer>
```
Just select the Lexer and start typing.