### PR TITLE
Fix MySQL lexer single comment render error

### DIFF
--- a/lexers/embedded/mysql.xml
+++ b/lexers/embedded/mysql.xml
@@ -38,7 +38,7 @@
       <rule pattern="\s+">
         <token type="TextWhitespace"/>
       </rule>
-      <rule pattern="(#|--\s+).*\n?">
+      <rule pattern="(#|--).*\n?">
         <token type="CommentSingle"/>
       </rule>
       <rule pattern="/\*">


### PR DESCRIPTION
fixes #1213 

Removing the mandatory space after `--` allowed the regex to correctly parse the inline comments and avoid matching actual code on empty `--`

After (using `chromad --csrf-key=moo`):
<img height="450" alt="image" src="https://github.com/user-attachments/assets/9cde3149-f9bb-4c4c-922c-396f47fb9c45" />

new regex matches the `sql.xml` single comment pattern

https://github.com/alecthomas/chroma/blob/17e5911b080afc465735539d861fab10e3646dcb/lexers/embedded/sql.xml#L15

I followed the instructions on AGENTS.md for running the project, since I'm never developed with go language, am not familiar with the environment and I couldn't find a build/run instructions elsewhere (since the project seems simple to run, I guess it was not needed).