### PR TITLE
styles: case-insensitive style registration and lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ formatter outputs raw tokens. The latter is useful for debugging lexers.
 ### Styles
 
 Chroma styles are defined in XML. The style entries use the
-[same syntax](http://pygments.org/docs/styles/) as Pygments.
-
-All Pygments styles have been converted to Chroma using the `_tools/style.py`
+[same syntax](http://pygments.org/docs/styles/) as Pygments. All Pygments styles have been converted to Chroma using the `_tools/style.py`
 script.
+
+Style names are case-insensitive. For example, `monokai` and `Monokai` are treated as the same style.
 
 When you work with one of [Chroma's styles](https://github.com/alecthomas/chroma/tree/master/styles),
 know that the `Background` token type provides the default style for tokens. It does so

--- a/cmd/chroma/go.sum
+++ b/cmd/chroma/go.sum
@@ -1,11 +1,9 @@
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.12.1 h1:iq6aMJDcFYP9uFrLdsiZQ2ZMmcshduyGv4Pek0MQPW0=
-github.com/alecthomas/kong v1.12.1/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
 github.com/alecthomas/kong v1.13.0 h1:5e/7XC3ugvhP1DQBmTS+WuHtCbcv44hsohMgcvVxSrA=
 github.com/alecthomas/kong v1.13.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
-github.com/alecthomas/repr v0.5.1 h1:E3G4t2QbHTSNpPKBgMTln5KLkZHLOcU7r37J4pXBuIg=
-github.com/alecthomas/repr v0.5.1/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
+github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -267,8 +267,7 @@ func main() {
 }
 
 func selectStyle() (*chroma.Style, error) {
-	style, ok := styles.Registry[cli.Style]
-	if ok {
+	if style := styles.Get(cli.Style); style != styles.Fallback {
 		return style, nil
 	}
 	r, err := os.Open(cli.Style)
@@ -434,7 +433,7 @@ func dumpXMLLexerDefinitions(dir string) error {
 				fmt.Fprintf(os.Stderr, "warning: %s already exists\n", filename)
 				continue
 			}
-			err = os.WriteFile(filename, data, 0600)
+			err = os.WriteFile(filename, data, 0o600)
 			if err != nil {
 				return err
 			}

--- a/cmd/chromad/main.go
+++ b/cmd/chromad/main.go
@@ -164,8 +164,8 @@ func newContext(r *http.Request) context {
 		ctx.Languages = append(ctx.Languages, lexer.Config().Name)
 	}
 	sort.Strings(ctx.Languages)
-	for _, style := range styles.Registry {
-		ctx.Styles = append(ctx.Styles, style.Name)
+	for name := range styles.Registry {
+		ctx.Styles = append(ctx.Styles, name)
 	}
 	sort.Strings(ctx.Styles)
 	return ctx

--- a/styles/api.go
+++ b/styles/api.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"sort"
+	"strings"
 
 	"github.com/alecthomas/chroma/v2"
 )
@@ -31,7 +32,7 @@ var Registry = func() map[string]*chroma.Style {
 		if err != nil {
 			panic(err)
 		}
-		registry[style.Name] = style
+		registry[strings.ToLower(style.Name)] = style
 		_ = r.Close()
 	}
 	return registry
@@ -42,7 +43,7 @@ var Fallback = Registry["swapoff"]
 
 // Register a chroma.Style.
 func Register(style *chroma.Style) *chroma.Style {
-	Registry[style.Name] = style
+	Registry[strings.ToLower(style.Name)] = style
 	return style
 }
 
@@ -58,7 +59,7 @@ func Names() []string {
 
 // Get named style, or Fallback.
 func Get(name string) *chroma.Style {
-	if style, ok := Registry[name]; ok {
+	if style, ok := Registry[strings.ToLower(name)]; ok {
 		return style
 	}
 	return Fallback

--- a/styles/api_test.go
+++ b/styles/api_test.go
@@ -1,0 +1,43 @@
+package styles
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/chroma/v2"
+)
+
+func TestStyleRegistryCaseInsensitivity(t *testing.T) {
+	// Verify that all keys in the Registry are lowercase.
+	for name := range Registry {
+		assert.Equal(t, strings.ToLower(name), name)
+	}
+
+	// Verify that Get is case-insensitive.
+	names := []string{"monokai", "Monokai", "MONOKAI"}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			style := Get(name)
+
+			assert.NotEqual(t, Fallback, style)
+			assert.True(t, strings.EqualFold(style.Name, name))
+		})
+	}
+}
+
+func TestGetUnknownStyleReturnsFallback(t *testing.T) {
+	assert.Equal(t, Fallback, Get("non-existent-style"))
+}
+
+func TestRegisterCaseInsensitivity(t *testing.T) {
+	custom := chroma.MustNewStyle("CustomStyle", chroma.StyleEntries{
+		chroma.Text: "#ffffff",
+	})
+	Register(custom)
+
+	assert.Equal(t, custom, Get("customstyle"))
+	assert.Equal(t, custom, Get("CUSTOMSTYLE"))
+	assert.Equal(t, custom, Get("CustomStyle"))
+}


### PR DESCRIPTION
Normalize style names to lowercase during registration and lookup to provide case-insensitive access across the library, CLI, and web interface.

Changes:

- Normalize keys to lowercase in `styles.Register()`.
- Convert input names to lowercase in `styles.Get()`.
- Update `cmd/chroma` and `cmd/chromad` to use these normalized keys.
- Add regression tests for library and CLI case-insensitivity.
- Update CI workflow to include tests for the `cmd/chroma` module.
- Update `README.md` to document case-insensitive style names.


Closes #1222