### PR TITLE
Add `.json5` to json Lexer

### DIFF
--- a/lexers/embedded/json.xml
+++ b/lexers/embedded/json.xml
@@ -4,6 +4,7 @@
     <alias>json</alias>
     <filename>*.json</filename>
     <filename>*.jsonc</filename>
+    <filename>*.json5</filename>
     <filename>*.avsc</filename>
     <mime_type>application/json</mime_type>
     <dot_all>true</dot_all>


### PR DESCRIPTION
Technically the JSON lexer is not ideal for json5 but I observe many people writing valid json or jsonc into `.json5` files ([random example](https://github.com/it-at-m/refarch/blob/main/renovate.json5)) so I think it's worth adding it. Here is a rendering of a JSON5 file with all features:

<img width="593" height="355" alt="image" src="https://github.com/user-attachments/assets/5248d3fe-954d-4a3f-9180-38bbe1260fe6" />
