### PR TITLE
fix: Dart single-line comment not matched at EOF without trailing newline

### DIFF
--- a/lexers/embedded/dart.xml
+++ b/lexers/embedded/dart.xml
@@ -81,7 +81,7 @@
       <rule pattern="[^\S\n]+">
         <token type="Text"/>
       </rule>
-      <rule pattern="//.*?\n">
+      <rule pattern="//[^\n]*\n?">
         <token type="CommentSingle"/>
       </rule>
       <rule pattern="/\*.*?\*/">


### PR DESCRIPTION
Fixes #1225

**Failing scenario:** A single-line comment (`// test`) at the end of a Dart file without a trailing newline is not tokenized as `CommentSingle`.

**Root cause:** The pattern `//.*?\n` requires a literal `\n`. With `dot_all: true`, the negated character class `[^\n]` is used instead of `.` to avoid matching across lines.

**Before:** `// test` at EOF → not matched, falls through to other rules
**After:** `// test` at EOF → correctly matched as `CommentSingle`

**Why the fix is correct:** `//[^\n]*\n?` matches from `//` to end-of-line using a negated character class (unaffected by `dot_all`), and the optional `\n?` preserves the existing behavior of including the trailing newline in the token when present.

**Validation:**
- `go test ./lexers/ -run TestLexers/Dart` — PASS
- `go test ./lexers/ -run TestLexers` (full suite) — PASS
- Manual verification: both `// test\n` and `// test<EOF>` tokenize correctly