### PR TITLE
feat(lexers): add support for Flint language

### DIFF
--- a/lexers/flint.go
+++ b/lexers/flint.go
@@ -1,0 +1,54 @@
+package lexers
+
+import (
+	"github.com/alecthomas/chroma/v2"
+)
+
+// Flint lexer.
+var Flint = Register(chroma.MustNewLexer(
+	&chroma.Config{
+		Name:      "Flint",
+		Aliases:   []string{"flint"},
+		Filenames: []string{"*.fl"},
+		MimeTypes: []string{"text/x-flint"},
+	},
+	func() chroma.Rules {
+		return chroma.Rules{
+			"root": {
+				// Comments
+				{Pattern: `--.*`, Type: chroma.CommentSingle},
+				{Pattern: `\{-[\s\S]*?-\}`, Type: chroma.CommentMultiline},
+
+				// Strings and Interpolation
+				{Pattern: `"(\\\\|\\"|[^"])*"`, Type: chroma.StringDouble},
+				{Pattern: "`[^`]*`", Type: chroma.StringBacktick},
+				{Pattern: `\$"(\\\\|\\"|[^"])*"`, Type: chroma.StringInterpol},
+				{Pattern: `\$` + "`[^`]*`", Type: chroma.StringInterpol},
+
+				// Keywords
+				{Pattern: `\b(import|as|if|else|for|while|stream|return|break|continue|fn|extern|var|const|struct)\b`, Type: chroma.Keyword},
+				{Pattern: `\b(true|false|null)\b`, Type: chroma.KeywordConstant},
+
+				// Types
+				{Pattern: `\b(int|float|string|bool|void|val|arr|dict)\b`, Type: chroma.KeywordType},
+
+				// Built-ins
+				{Pattern: `\b(print|printerr|len|push|range|if_fail|fallback|ensure|to_int|to_str|to_float|clone|lines|chars|grep|embed_file|type_of)\b`, Type: chroma.NameBuiltin},
+
+				// Numbers
+				{Pattern: `\b\d+(\.\d+)?([eE][+-]?\d+)?\b`, Type: chroma.Number},
+
+				// Operators
+				{Pattern: `~>`, Type: chroma.Operator},
+				{Pattern: `[+/*%=<>&|!\-\.]+`, Type: chroma.Operator},
+
+				// Identifiers and Punctuation
+				{Pattern: `[a-zA-Z_]\w*`, Type: chroma.Name},
+				{Pattern: `[{}()\[\],;:]`, Type: chroma.Punctuation},
+
+				// Whitespace
+				{Pattern: `\s+`, Type: chroma.Text},
+			},
+		}
+	},
+))


### PR DESCRIPTION
This PR adds a lexer for the [Flint](https://github.com/the-flint-lang/flint) programming language.

Flint is a fast, pipeline-oriented AOT language for system scripting that compiles to C99.

**Changes:**
- Added `lexers/flint.go` covering keywords, built-ins, types, and the pipeline operator (`~>`).
- Tested with `go test ./lexers/...` — passed.