### PR TITLE
fix(gas): match single-line comments without trailing newline (#1246)

### DIFF
--- a/lexers/embedded/gas.xml
+++ b/lexers/embedded/gas.xml
@@ -56,7 +56,7 @@
         <token type="Text"/>
         <pop depth="1"/>
       </rule>
-      <rule pattern="([;#]|//).*?\n">
+      <rule pattern="([;#]|//)[^\n]*">
         <token type="CommentSingle"/>
         <pop depth="1"/>
       </rule>
@@ -114,7 +114,7 @@
         <token type="Text"/>
         <pop depth="1"/>
       </rule>
-      <rule pattern="([;#]|//).*?\n">
+      <rule pattern="([;#]|//)[^\n]*">
         <token type="CommentSingle"/>
         <pop depth="1"/>
       </rule>
@@ -139,7 +139,7 @@
       <rule pattern="\s+">
         <token type="Text"/>
       </rule>
-      <rule pattern="([;#]|//).*?\n">
+      <rule pattern="([;#]|//)[^\n]*">
         <token type="CommentSingle"/>
       </rule>
       <rule pattern="/[*][\w\W]*?[*]/">


### PR DESCRIPTION
## Summary

The GAS lexer regex `([;#]|//).*?\n` requires a trailing newline to match, so when a file's final line is a comment without an EOL the lexer fails to tokenize it as a comment.

This PR switches the three comment regexes in `lexers/embedded/gas.xml` to `([;#]|//)[^\n]*`, which matches up to end-of-line *or* end-of-input.

Fixes #1246

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./lexers/...\` passes (\`ok github.com/alecthomas/chroma/v2/lexers 6.699s\`)