### PR TITLE
Update Solarized Light to use correct background color

### DIFF
--- a/styles/solarized-light.xml
+++ b/styles/solarized-light.xml
@@ -1,5 +1,5 @@
 <style name="solarized-light">
-  <entry type="Background" style="bg:#eee8d5"/>
+  <entry type="Background" style="bg:#fdf6e3"/>
   <entry type="Keyword" style="#859900"/>
   <entry type="KeywordConstant" style="bold"/>
   <entry type="KeywordNamespace" style="bold #dc322f"/>


### PR DESCRIPTION
The Background color for Solarized Light is set to `#eee8d5`, though this a darker shade than most implementations of Solarized. Based on the [hex values](https://ethanschoonover.com/solarized/#:~:text=The%20Values) on the Solarized website, this is the "base 2 - background highlights" color instead of the "base 3" one that's meant for background use (`#fdf6e3`); this PR swaps in that value instead.

It looks like this was previously proposed as part of #469 long ago, though that also included a number of other changes; hoping this one alone is a bit less controversial 😁