### PR TITLE
Improve Nu file detection

### DIFF
--- a/lexers/embedded/nu.xml
+++ b/lexers/embedded/nu.xml
@@ -3,7 +3,12 @@
     <name>Nu</name>
     <alias>nu</alias>
     <filename>*.nu</filename>
+    <mime_type>application/x-shellscript</mime_type>
     <mime_type>text/plain</mime_type>
+    <mime_type>text/x-shellscript</mime_type>
+    <analyse first="true" >
+      <regex pattern="(?m)^#!.*/bin/(?:env(?: -[a-zA-Z0-9]+)*(?: --[a-zA-Z0-9-=]+)* |)nu" score="1.0" />
+    </analyse>
   </config>
   <rules>
     <state name="root">


### PR DESCRIPTION
This adds shebang detection (including arguments to `env`) and `x-shellscript` mime types to the Nu lexer.

As far as I can see there are no tests for this that I could/should update. Please do point out if I missed anything in that regard.

Fixes #1259.