### PR TITLE
feat: add JSONL support to JSON lexer

### DIFF
--- a/lexers/embedded/json.xml
+++ b/lexers/embedded/json.xml
@@ -2,10 +2,13 @@
   <config>
     <name>JSON</name>
     <alias>json</alias>
+    <alias>jsonl</alias>
     <filename>*.json</filename>
+    <filename>*.jsonl</filename>
     <filename>*.jsonc</filename>
     <filename>*.avsc</filename>
     <mime_type>application/json</mime_type>
+    <mime_type>application/jsonl</mime_type>
     <dot_all>true</dot_all>
     <not_multiline>true</not_multiline>
   </config>

--- a/lexers/testdata/jsonl.actual
+++ b/lexers/testdata/jsonl.actual
@@ -1,0 +1,2 @@
+{"name": "Alice"}
+{"name": "Bob"}

--- a/lexers/testdata/jsonl.expected
+++ b/lexers/testdata/jsonl.expected
@@ -1,0 +1,16 @@
+[
+  {"type":"Punctuation","value":"{"},
+  {"type":"NameTag","value":"\"name\""},
+  {"type":"Punctuation","value":":"},
+  {"type":"Text","value":" "},
+  {"type":"LiteralStringDouble","value":"\"Alice\""},
+  {"type":"Punctuation","value":"}"},
+  {"type":"Text","value":"\n"},
+  {"type":"Punctuation","value":"{"},
+  {"type":"NameTag","value":"\"name\""},
+  {"type":"Punctuation","value":":"},
+  {"type":"Text","value":" "},
+  {"type":"LiteralStringDouble","value":"\"Bob\""},
+  {"type":"Punctuation","value":"}"},
+  {"type":"Text","value":"\n"}
+]

--- a/test.jsonl
+++ b/test.jsonl
@@ -1,0 +1,2 @@
+{"name": "Alice"}
+{"name": "Bob"}


### PR DESCRIPTION
### Description
This PR adds support for JSON Lines (JSONL) to the existing JSON lexer.

Because the existing JSON lexer already handles repeating objects natively, this implementation simply maps the \`jsonl\` file extension, alias, and mime type to the \`JSON\` lexer configuration without needing any underlying state machine changes.

Inspired by https://github.com/walles/moor/pull/407.

### Changes
* **Alias added:** \`jsonl\`
* **File extension added:** \`*.jsonl\`
* **MIME type added:** \`application/jsonl\`
* **Tests:** Added \`jsonl.actual\` and \`jsonl.expected\` validation files to ensure tokens are correctly extracted across newlines in \`.jsonl\` files.

### Testing
Ran \`go test ./lexers -run TestLexers\` locally to verify that JSON Lines objects format accurately and consistently.