### PR TITLE
lexers/nu: detect via #!/usr/bin/env nu shebang too

### DIFF
--- a/lexers/embedded/nu.xml
+++ b/lexers/embedded/nu.xml
@@ -4,6 +4,9 @@
     <alias>nu</alias>
     <filename>*.nu</filename>
     <mime_type>text/plain</mime_type>
+    <analyse first="true" >
+      <regex pattern="(?m)^#!.*/bin/(?:env |)nu(?:shell)?\b" score="1.0" />
+    </analyse>
   </config>
   <rules>
     <state name="root">


### PR DESCRIPTION
Closes #1259.

Nu only matched the `*.nu` filename, so a shebang-only file (no extension) ended up as plain text. Add the same analyser pattern `bash.xml` uses, scoped to `nu` / `nushell`.