### PR TITLE
formatters/html: drop -moz-tab-size and -o-tab-size prefixes

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -437,7 +437,7 @@ func (f *Formatter) styleAttrWithMode(styles map[chroma.TokenType]string, tt chr
 
 func (f *Formatter) tabWidthStyle() string {
 	if f.tabWidth != 0 && f.tabWidth != 8 {
-		return fmt.Sprintf("-moz-tab-size: %[1]d; -o-tab-size: %[1]d; tab-size: %[1]d;", f.tabWidth)
+		return fmt.Sprintf("tab-size: %d;", f.tabWidth)
 	}
 	return ""
 }

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -160,7 +160,7 @@ func TestTabWidthStyle(t *testing.T) {
 	err = f.Format(&buf, styles.Fallback, it)
 	assert.NoError(t, err)
 
-	assert.True(t, regexp.MustCompile(`<pre.*style=".*background-color:[^;]+;-moz-tab-size:4;-o-tab-size:4;tab-size:4;[^"]*".+`).MatchString(buf.String()))
+	assert.True(t, regexp.MustCompile(`<pre.*style=".*background-color:[^;]+;tab-size:4;[^"]*".+`).MatchString(buf.String()))
 }
 
 func TestWithCustomCSS(t *testing.T) {


### PR DESCRIPTION
Both vendor prefixes are obsolete. Per MDN's browser-compat table, Opera supports unprefixed \`tab-size\` since 2013 and Firefox switched in v91 (2021), so every browser that's going to read chroma's HTML output today understands the bare \`tab-size\` property. silverwind already voted for this in the issue thread.

fixes #1059