### PR TITLE
Add missing NameAttribute entry to github-dark.xml

### DIFF
--- a/styles/github-dark.xml
+++ b/styles/github-dark.xml
@@ -7,6 +7,7 @@
   <entry type="KeywordConstant" style="#79c0ff"/>
   <entry type="KeywordPseudo" style="#79c0ff"/>
   <entry type="Name" style="#e6edf3"/>
+  <entry type="NameAttribute" style="#f0883e"/>
   <entry type="NameClass" style="bold #f0883e"/>
   <entry type="NameConstant" style="bold #79c0ff"/>
   <entry type="NameDecorator" style="bold #d2a8ff"/>


### PR DESCRIPTION
* NameAttribute has the same color as NameClass in github.xml, so I followed that same pattern.
* There are some other missing types in github-dark.xml, but this was the most obvious missing piece looking at some samples.
