### PR TITLE
Quality: Unsafe type assertion in panic recovery will re-panic for non-error values

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -1,6 +1,7 @@
 package chroma
 
 import (
+	"fmt"
 	"io"
 	"iter"
 )
@@ -21,7 +22,11 @@ type FormatterFunc func(w io.Writer, style *Style, iterator iter.Seq[Token]) err
 func (f FormatterFunc) Format(w io.Writer, s *Style, it iter.Seq[Token]) (err error) {
 	defer func() {
 		if perr := recover(); perr != nil {
-			err = perr.(error)
+			if e, ok := perr.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("%v", perr)
+			}
 		}
 	}()
 	return f(w, s, it)
@@ -34,7 +39,11 @@ type recoveringFormatter struct {
 func (r recoveringFormatter) Format(w io.Writer, s *Style, it iter.Seq[Token]) (err error) {
 	defer func() {
 		if perr := recover(); perr != nil {
-			err = perr.(error)
+			if e, ok := perr.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("%v", perr)
+			}
 		}
 	}()
 	return r.Formatter.Format(w, s, it)


### PR DESCRIPTION
## Problem

Both `FormatterFunc.Format` and `recoveringFormatter.Format` use `perr.(error)` to
convert the recovered panic value to an error. This is a bare type assertion (no comma-ok),
so if the panic value is not an `error` (e.g., `panic("something")`, `panic(42)` — both
common idioms in Go and in third-party code), the type assertion itself panics with
"interface conversion: interface is string, not error". This completely defeats the purpose
of the panic-recovery wrapper, crashing the caller instead of converting the panic to an error.

This affects both recover sites (FormatterFunc at ~line 18 and recoveringFormatter at ~line 30).


**Severity**: `high`
**File**: `formatter.go`

## Solution

Replace the bare type assertion with a type switch or comma-ok pattern at both sites:

In FormatterFunc.Format (line ~18):


## Changes

- `formatter.go` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
