### PR TITLE
Add the 'Tomorrow' theme

### DIFF
--- a/styles/tomorrow-night-blue.xml
+++ b/styles/tomorrow-night-blue.xml
@@ -1,0 +1,78 @@
+<style name="tomorrow-night-blue">
+  <entry type="Background" style="#FFFFFF bg:#002451"/>
+  <entry type="Error" style="#FFFFFF bg:#F99DA5"/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#00346E"/>
+  <entry type="LineNumbersTable" style="#7285B7"/>
+  <entry type="LineNumbers" style="#7285B7"/>
+  <entry type="Keyword" style="#EBBBFF"/>
+  <entry type="KeywordConstant" style="#FFC58F"/>
+  <entry type="KeywordDeclaration" style="#EBBBFF"/>
+  <entry type="KeywordNamespace" style="#EBBBFF"/>
+  <entry type="KeywordPseudo" style="#EBBBFF"/>
+  <entry type="KeywordReserved" style="#EBBBFF"/>
+  <entry type="KeywordType" style="#FFEEAD"/>
+  <entry type="Name" style="#FFFFFF"/>
+  <entry type="NameAttribute" style="#FF9DA4"/>
+  <entry type="NameBuiltin" style="#BBDAFF"/>
+  <entry type="NameBuiltinPseudo" style="#FFC58F"/>
+  <entry type="NameClass" style="#FFEEAD"/>
+  <entry type="NameConstant" style="#FFC58F"/>
+  <entry type="NameDecorator" style="#FFEEAD"/>
+  <entry type="NameEntity" style="#FF9DA4"/>
+  <entry type="NameException" style="#FFEEAD"/>
+  <entry type="NameFunction" style="#BBDAFF"/>
+  <entry type="NameLabel" style="#BBDAFF"/>
+  <entry type="NameNamespace" style="#D1F1A9"/>
+  <entry type="NameOther" style="#FFFFFF"/>
+  <entry type="NameTag" style="#FF9DA4"/>
+  <entry type="NameVariable" style="#FF9DA4"/>
+  <entry type="NameVariableClass" style="#FF9DA4"/>
+  <entry type="NameVariableGlobal" style="#FF9DA4"/>
+  <entry type="NameVariableInstance" style="#FF9DA4"/>
+  <entry type="Literal" style="#FFFFFF"/>
+  <entry type="LiteralDate" style="#FFC58F"/>
+  <entry type="LiteralString" style="#D1F1A9"/>
+  <entry type="LiteralStringBacktick" style="#D1F1A9"/>
+  <entry type="LiteralStringChar" style="#D1F1A9"/>
+  <entry type="LiteralStringDoc" style="italic #D1F1A9"/>
+  <entry type="LiteralStringDouble" style="#D1F1A9"/>
+  <entry type="LiteralStringEscape" style="#FFC58F"/>
+  <entry type="LiteralStringHeredoc" style="#D1F1A9"/>
+  <entry type="LiteralStringInterpol" style="#FFC58F"/>
+  <entry type="LiteralStringOther" style="#D1F1A9"/>
+  <entry type="LiteralStringRegex" style="#FF9DA4"/>
+  <entry type="LiteralStringSingle" style="#D1F1A9"/>
+  <entry type="LiteralStringSymbol" style="#D1F1A9"/>
+  <entry type="LiteralNumber" style="#FFC58F"/>
+  <entry type="LiteralNumberBin" style="#FFC58F"/>
+  <entry type="LiteralNumberFloat" style="#FFC58F"/>
+  <entry type="LiteralNumberHex" style="#FFC58F"/>
+  <entry type="LiteralNumberInteger" style="#FFC58F"/>
+  <entry type="LiteralNumberIntegerLong" style="#FFC58F"/>
+  <entry type="LiteralNumberOct" style="#FFC58F"/>
+  <entry type="Operator" style="#99FFFF"/>
+  <entry type="OperatorWord" style="#99FFFF"/>
+  <entry type="Punctuation" style="#FFFFFF"/>
+  <entry type="Comment" style="italic #7285B7"/>
+  <entry type="CommentHashbang" style="italic #7285B7"/>
+  <entry type="CommentMultiline" style="italic #7285B7"/>
+  <entry type="CommentSingle" style="italic #7285B7"/>
+  <entry type="CommentSpecial" style="italic bold #7285B7"/>
+  <entry type="CommentPreproc" style="#EBBBFF"/>
+  <entry type="Generic" style="#FFFFFF"/>
+  <entry type="GenericDeleted" style="#FF9DA4"/>
+  <entry type="GenericEmph" style="italic"/>
+  <entry type="GenericError" style="#FF9DA4"/>
+  <entry type="GenericHeading" style="bold #D1F1A9"/>
+  <entry type="GenericInserted" style="bold #D1F1A9"/>
+  <entry type="GenericOutput" style="#7285B7"/>
+  <entry type="GenericPrompt" style="#7285B7"/>
+  <entry type="GenericStrong" style="bold"/>
+  <entry type="GenericSubheading" style="bold #D1F1A9"/>
+  <entry type="GenericTraceback" style="#FF9DA4"/>
+  <entry type="GenericUnderline" style="underline"/>
+  <entry type="Text" style="#FFFFFF"/>
+  <entry type="TextWhitespace" style="#FFFFFF"/>
+  <entry type="Other" style="#FFFFFF"/>
+</style>

--- a/styles/tomorrow-night-bright.xml
+++ b/styles/tomorrow-night-bright.xml
@@ -1,0 +1,78 @@
+<style name="tomorrow-night-bright">
+  <entry type="Background" style="#DEDEDE bg:#000000"/>
+  <entry type="Error" style="#CED2CF bg:#DF5F5F"/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#2A2A2A"/>
+  <entry type="LineNumbersTable" style="#969896"/>
+  <entry type="LineNumbers" style="#969896"/>
+  <entry type="Keyword" style="#C397D8"/>
+  <entry type="KeywordConstant" style="#E78C45"/>
+  <entry type="KeywordDeclaration" style="#C397D8"/>
+  <entry type="KeywordNamespace" style="#C397D8"/>
+  <entry type="KeywordPseudo" style="#C397D8"/>
+  <entry type="KeywordReserved" style="#C397D8"/>
+  <entry type="KeywordType" style="#E7C547"/>
+  <entry type="Name" style="#DEDEDE"/>
+  <entry type="NameAttribute" style="#D54E53"/>
+  <entry type="NameBuiltin" style="#7AA6DA"/>
+  <entry type="NameBuiltinPseudo" style="#E78C45"/>
+  <entry type="NameClass" style="#E7C547"/>
+  <entry type="NameConstant" style="#E78C45"/>
+  <entry type="NameDecorator" style="#E7C547"/>
+  <entry type="NameEntity" style="#D54E53"/>
+  <entry type="NameException" style="#E7C547"/>
+  <entry type="NameFunction" style="#7AA6DA"/>
+  <entry type="NameLabel" style="#7AA6DA"/>
+  <entry type="NameNamespace" style="#B9CA4A"/>
+  <entry type="NameOther" style="#DEDEDE"/>
+  <entry type="NameTag" style="#D54E53"/>
+  <entry type="NameVariable" style="#D54E53"/>
+  <entry type="NameVariableClass" style="#D54E53"/>
+  <entry type="NameVariableGlobal" style="#D54E53"/>
+  <entry type="NameVariableInstance" style="#D54E53"/>
+  <entry type="Literal" style="#DEDEDE"/>
+  <entry type="LiteralDate" style="#E78C45"/>
+  <entry type="LiteralString" style="#B9CA4A"/>
+  <entry type="LiteralStringBacktick" style="#B9CA4A"/>
+  <entry type="LiteralStringChar" style="#B9CA4A"/>
+  <entry type="LiteralStringDoc" style="italic #B9CA4A"/>
+  <entry type="LiteralStringDouble" style="#B9CA4A"/>
+  <entry type="LiteralStringEscape" style="#E78C45"/>
+  <entry type="LiteralStringHeredoc" style="#B9CA4A"/>
+  <entry type="LiteralStringInterpol" style="#E78C45"/>
+  <entry type="LiteralStringOther" style="#B9CA4A"/>
+  <entry type="LiteralStringRegex" style="#D54E53"/>
+  <entry type="LiteralStringSingle" style="#B9CA4A"/>
+  <entry type="LiteralStringSymbol" style="#B9CA4A"/>
+  <entry type="LiteralNumber" style="#E78C45"/>
+  <entry type="LiteralNumberBin" style="#E78C45"/>
+  <entry type="LiteralNumberFloat" style="#E78C45"/>
+  <entry type="LiteralNumberHex" style="#E78C45"/>
+  <entry type="LiteralNumberInteger" style="#E78C45"/>
+  <entry type="LiteralNumberIntegerLong" style="#E78C45"/>
+  <entry type="LiteralNumberOct" style="#E78C45"/>
+  <entry type="Operator" style="#70C0B1"/>
+  <entry type="OperatorWord" style="#70C0B1"/>
+  <entry type="Punctuation" style="#DEDEDE"/>
+  <entry type="Comment" style="italic #969896"/>
+  <entry type="CommentHashbang" style="italic #969896"/>
+  <entry type="CommentMultiline" style="italic #969896"/>
+  <entry type="CommentSingle" style="italic #969896"/>
+  <entry type="CommentSpecial" style="italic bold #969896"/>
+  <entry type="CommentPreproc" style="#C397D8"/>
+  <entry type="Generic" style="#DEDEDE"/>
+  <entry type="GenericDeleted" style="#D54E53"/>
+  <entry type="GenericEmph" style="italic"/>
+  <entry type="GenericError" style="#D54E53"/>
+  <entry type="GenericHeading" style="bold #B9CA4A"/>
+  <entry type="GenericInserted" style="bold #B9CA4A"/>
+  <entry type="GenericOutput" style="#969896"/>
+  <entry type="GenericPrompt" style="#969896"/>
+  <entry type="GenericStrong" style="bold"/>
+  <entry type="GenericSubheading" style="bold #B9CA4A"/>
+  <entry type="GenericTraceback" style="#D54E53"/>
+  <entry type="GenericUnderline" style="underline"/>
+  <entry type="Text" style="#DEDEDE"/>
+  <entry type="TextWhitespace" style="#DEDEDE"/>
+  <entry type="Other" style="#DEDEDE"/>
+</style>

--- a/styles/tomorrow-night-eighties.xml
+++ b/styles/tomorrow-night-eighties.xml
@@ -1,0 +1,78 @@
+<style name="tomorrow-night-eighties">
+  <entry type="Background" style="#CCCCCC bg:#2D2D2D"/>
+  <entry type="Error" style="#CDCDCD bg:#F2777A"/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#393939"/>
+  <entry type="LineNumbersTable" style="#999999"/>
+  <entry type="LineNumbers" style="#999999"/>
+  <entry type="Keyword" style="#CC99CC"/>
+  <entry type="KeywordConstant" style="#F99157"/>
+  <entry type="KeywordDeclaration" style="#CC99CC"/>
+  <entry type="KeywordNamespace" style="#CC99CC"/>
+  <entry type="KeywordPseudo" style="#CC99CC"/>
+  <entry type="KeywordReserved" style="#CC99CC"/>
+  <entry type="KeywordType" style="#FFCC66"/>
+  <entry type="Name" style="#CCCCCC"/>
+  <entry type="NameAttribute" style="#F2777A"/>
+  <entry type="NameBuiltin" style="#6699CC"/>
+  <entry type="NameBuiltinPseudo" style="#F99157"/>
+  <entry type="NameClass" style="#FFCC66"/>
+  <entry type="NameConstant" style="#F99157"/>
+  <entry type="NameDecorator" style="#FFCC66"/>
+  <entry type="NameEntity" style="#F2777A"/>
+  <entry type="NameException" style="#FFCC66"/>
+  <entry type="NameFunction" style="#6699CC"/>
+  <entry type="NameLabel" style="#6699CC"/>
+  <entry type="NameNamespace" style="#99CC99"/>
+  <entry type="NameOther" style="#CCCCCC"/>
+  <entry type="NameTag" style="#F2777A"/>
+  <entry type="NameVariable" style="#F2777A"/>
+  <entry type="NameVariableClass" style="#F2777A"/>
+  <entry type="NameVariableGlobal" style="#F2777A"/>
+  <entry type="NameVariableInstance" style="#F2777A"/>
+  <entry type="Literal" style="#CCCCCC"/>
+  <entry type="LiteralDate" style="#F99157"/>
+  <entry type="LiteralString" style="#99CC99"/>
+  <entry type="LiteralStringBacktick" style="#99CC99"/>
+  <entry type="LiteralStringChar" style="#99CC99"/>
+  <entry type="LiteralStringDoc" style="italic #99CC99"/>
+  <entry type="LiteralStringDouble" style="#99CC99"/>
+  <entry type="LiteralStringEscape" style="#F99157"/>
+  <entry type="LiteralStringHeredoc" style="#99CC99"/>
+  <entry type="LiteralStringInterpol" style="#F99157"/>
+  <entry type="LiteralStringOther" style="#99CC99"/>
+  <entry type="LiteralStringRegex" style="#F2777A"/>
+  <entry type="LiteralStringSingle" style="#99CC99"/>
+  <entry type="LiteralStringSymbol" style="#99CC99"/>
+  <entry type="LiteralNumber" style="#F99157"/>
+  <entry type="LiteralNumberBin" style="#F99157"/>
+  <entry type="LiteralNumberFloat" style="#F99157"/>
+  <entry type="LiteralNumberHex" style="#F99157"/>
+  <entry type="LiteralNumberInteger" style="#F99157"/>
+  <entry type="LiteralNumberIntegerLong" style="#F99157"/>
+  <entry type="LiteralNumberOct" style="#F99157"/>
+  <entry type="Operator" style="#66CCCC"/>
+  <entry type="OperatorWord" style="#66CCCC"/>
+  <entry type="Punctuation" style="#CCCCCC"/>
+  <entry type="Comment" style="italic #999999"/>
+  <entry type="CommentHashbang" style="italic #999999"/>
+  <entry type="CommentMultiline" style="italic #999999"/>
+  <entry type="CommentSingle" style="italic #999999"/>
+  <entry type="CommentSpecial" style="italic bold #999999"/>
+  <entry type="CommentPreproc" style="#CC99CC"/>
+  <entry type="Generic" style="#CCCCCC"/>
+  <entry type="GenericDeleted" style="#F2777A"/>
+  <entry type="GenericEmph" style="italic"/>
+  <entry type="GenericError" style="#F2777A"/>
+  <entry type="GenericHeading" style="bold #99CC99"/>
+  <entry type="GenericInserted" style="bold #99CC99"/>
+  <entry type="GenericOutput" style="#999999"/>
+  <entry type="GenericPrompt" style="#999999"/>
+  <entry type="GenericStrong" style="bold"/>
+  <entry type="GenericSubheading" style="bold #99CC99"/>
+  <entry type="GenericTraceback" style="#F2777A"/>
+  <entry type="GenericUnderline" style="underline"/>
+  <entry type="Text" style="#CCCCCC"/>
+  <entry type="TextWhitespace" style="#CCCCCC"/>
+  <entry type="Other" style="#CCCCCC"/>
+</style>

--- a/styles/tomorrow-night.xml
+++ b/styles/tomorrow-night.xml
@@ -1,0 +1,78 @@
+<style name="tomorrow-night" counterpart="tomorrow">
+  <entry type="Background" style="#C5C8C6 bg:#1D1F21"/>
+  <entry type="Error" style="#CED2CF bg:#DF5F5F"/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#282A2E"/>
+  <entry type="LineNumbersTable" style="#969896"/>
+  <entry type="LineNumbers" style="#969896"/>
+  <entry type="Keyword" style="#B294BB"/>
+  <entry type="KeywordConstant" style="#DE935F"/>
+  <entry type="KeywordDeclaration" style="#B294BB"/>
+  <entry type="KeywordNamespace" style="#B294BB"/>
+  <entry type="KeywordPseudo" style="#B294BB"/>
+  <entry type="KeywordReserved" style="#B294BB"/>
+  <entry type="KeywordType" style="#F0C674"/>
+  <entry type="Name" style="#C5C8C6"/>
+  <entry type="NameAttribute" style="#CC6666"/>
+  <entry type="NameBuiltin" style="#81A2BE"/>
+  <entry type="NameBuiltinPseudo" style="#DE935F"/>
+  <entry type="NameClass" style="#F0C674"/>
+  <entry type="NameConstant" style="#DE935F"/>
+  <entry type="NameDecorator" style="#F0C674"/>
+  <entry type="NameEntity" style="#CC6666"/>
+  <entry type="NameException" style="#F0C674"/>
+  <entry type="NameFunction" style="#81A2BE"/>
+  <entry type="NameLabel" style="#81A2BE"/>
+  <entry type="NameNamespace" style="#B5BD68"/>
+  <entry type="NameOther" style="#C5C8C6"/>
+  <entry type="NameTag" style="#CC6666"/>
+  <entry type="NameVariable" style="#CC6666"/>
+  <entry type="NameVariableClass" style="#CC6666"/>
+  <entry type="NameVariableGlobal" style="#CC6666"/>
+  <entry type="NameVariableInstance" style="#CC6666"/>
+  <entry type="Literal" style="#C5C8C6"/>
+  <entry type="LiteralDate" style="#DE935F"/>
+  <entry type="LiteralString" style="#B5BD68"/>
+  <entry type="LiteralStringBacktick" style="#B5BD68"/>
+  <entry type="LiteralStringChar" style="#B5BD68"/>
+  <entry type="LiteralStringDoc" style="italic #B5BD68"/>
+  <entry type="LiteralStringDouble" style="#B5BD68"/>
+  <entry type="LiteralStringEscape" style="#DE935F"/>
+  <entry type="LiteralStringHeredoc" style="#B5BD68"/>
+  <entry type="LiteralStringInterpol" style="#DE935F"/>
+  <entry type="LiteralStringOther" style="#B5BD68"/>
+  <entry type="LiteralStringRegex" style="#CC6666"/>
+  <entry type="LiteralStringSingle" style="#B5BD68"/>
+  <entry type="LiteralStringSymbol" style="#B5BD68"/>
+  <entry type="LiteralNumber" style="#DE935F"/>
+  <entry type="LiteralNumberBin" style="#DE935F"/>
+  <entry type="LiteralNumberFloat" style="#DE935F"/>
+  <entry type="LiteralNumberHex" style="#DE935F"/>
+  <entry type="LiteralNumberInteger" style="#DE935F"/>
+  <entry type="LiteralNumberIntegerLong" style="#DE935F"/>
+  <entry type="LiteralNumberOct" style="#DE935F"/>
+  <entry type="Operator" style="#8ABEB7"/>
+  <entry type="OperatorWord" style="#8ABEB7"/>
+  <entry type="Punctuation" style="#C5C8C6"/>
+  <entry type="Comment" style="italic #969896"/>
+  <entry type="CommentHashbang" style="italic #969896"/>
+  <entry type="CommentMultiline" style="italic #969896"/>
+  <entry type="CommentSingle" style="italic #969896"/>
+  <entry type="CommentSpecial" style="italic bold #969896"/>
+  <entry type="CommentPreproc" style="#B294BB"/>
+  <entry type="Generic" style="#C5C8C6"/>
+  <entry type="GenericDeleted" style="#CC6666"/>
+  <entry type="GenericEmph" style="italic"/>
+  <entry type="GenericError" style="#CC6666"/>
+  <entry type="GenericHeading" style="bold #B5BD68"/>
+  <entry type="GenericInserted" style="bold #B5BD68"/>
+  <entry type="GenericOutput" style="#969896"/>
+  <entry type="GenericPrompt" style="#969896"/>
+  <entry type="GenericStrong" style="bold"/>
+  <entry type="GenericSubheading" style="bold #B5BD68"/>
+  <entry type="GenericTraceback" style="#CC6666"/>
+  <entry type="GenericUnderline" style="underline"/>
+  <entry type="Text" style="#C5C8C6"/>
+  <entry type="TextWhitespace" style="#C5C8C6"/>
+  <entry type="Other" style="#C5C8C6"/>
+</style>

--- a/styles/tomorrow.xml
+++ b/styles/tomorrow.xml
@@ -1,0 +1,78 @@
+<style name="tomorrow" counterpart="tomorrow-night">
+  <entry type="Background" style="#4D4D4C bg:#FFFFFF"/>
+  <entry type="Error" style="#FFFFFF bg:#C82829"/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#EFEFEF"/>
+  <entry type="LineNumbersTable" style="#8E908C"/>
+  <entry type="LineNumbers" style="#8E908C"/>
+  <entry type="Keyword" style="#8959A8"/>
+  <entry type="KeywordConstant" style="#F5871F"/>
+  <entry type="KeywordDeclaration" style="#8959A8"/>
+  <entry type="KeywordNamespace" style="#8959A8"/>
+  <entry type="KeywordPseudo" style="#8959A8"/>
+  <entry type="KeywordReserved" style="#8959A8"/>
+  <entry type="KeywordType" style="#C99E00"/>
+  <entry type="Name" style="#4D4D4C"/>
+  <entry type="NameAttribute" style="#C82829"/>
+  <entry type="NameBuiltin" style="#4271AE"/>
+  <entry type="NameBuiltinPseudo" style="#F5871F"/>
+  <entry type="NameClass" style="#C99E00"/>
+  <entry type="NameConstant" style="#F5871F"/>
+  <entry type="NameDecorator" style="#C99E00"/>
+  <entry type="NameEntity" style="#C82829"/>
+  <entry type="NameException" style="#C99E00"/>
+  <entry type="NameFunction" style="#4271AE"/>
+  <entry type="NameLabel" style="#4271AE"/>
+  <entry type="NameNamespace" style="#718C00"/>
+  <entry type="NameOther" style="#4D4D4C"/>
+  <entry type="NameTag" style="#C82829"/>
+  <entry type="NameVariable" style="#C82829"/>
+  <entry type="NameVariableClass" style="#C82829"/>
+  <entry type="NameVariableGlobal" style="#C82829"/>
+  <entry type="NameVariableInstance" style="#C82829"/>
+  <entry type="Literal" style="#4D4D4C"/>
+  <entry type="LiteralDate" style="#F5871F"/>
+  <entry type="LiteralString" style="#718C00"/>
+  <entry type="LiteralStringBacktick" style="#718C00"/>
+  <entry type="LiteralStringChar" style="#718C00"/>
+  <entry type="LiteralStringDoc" style="italic #718C00"/>
+  <entry type="LiteralStringDouble" style="#718C00"/>
+  <entry type="LiteralStringEscape" style="#F5871F"/>
+  <entry type="LiteralStringHeredoc" style="#718C00"/>
+  <entry type="LiteralStringInterpol" style="#F5871F"/>
+  <entry type="LiteralStringOther" style="#718C00"/>
+  <entry type="LiteralStringRegex" style="#C82829"/>
+  <entry type="LiteralStringSingle" style="#718C00"/>
+  <entry type="LiteralStringSymbol" style="#718C00"/>
+  <entry type="LiteralNumber" style="#F5871F"/>
+  <entry type="LiteralNumberBin" style="#F5871F"/>
+  <entry type="LiteralNumberFloat" style="#F5871F"/>
+  <entry type="LiteralNumberHex" style="#F5871F"/>
+  <entry type="LiteralNumberInteger" style="#F5871F"/>
+  <entry type="LiteralNumberIntegerLong" style="#F5871F"/>
+  <entry type="LiteralNumberOct" style="#F5871F"/>
+  <entry type="Operator" style="#3E999F"/>
+  <entry type="OperatorWord" style="#3E999F"/>
+  <entry type="Punctuation" style="#4D4D4C"/>
+  <entry type="Comment" style="italic #8E908C"/>
+  <entry type="CommentHashbang" style="italic #8E908C"/>
+  <entry type="CommentMultiline" style="italic #8E908C"/>
+  <entry type="CommentSingle" style="italic #8E908C"/>
+  <entry type="CommentSpecial" style="italic bold #8E908C"/>
+  <entry type="CommentPreproc" style="#8959A8"/>
+  <entry type="Generic" style="#4D4D4C"/>
+  <entry type="GenericDeleted" style="#C82829"/>
+  <entry type="GenericEmph" style="italic"/>
+  <entry type="GenericError" style="#C82829"/>
+  <entry type="GenericHeading" style="bold #718C00"/>
+  <entry type="GenericInserted" style="bold #718C00"/>
+  <entry type="GenericOutput" style="#8E908C"/>
+  <entry type="GenericPrompt" style="#8E908C"/>
+  <entry type="GenericStrong" style="bold"/>
+  <entry type="GenericSubheading" style="bold #718C00"/>
+  <entry type="GenericTraceback" style="#C82829"/>
+  <entry type="GenericUnderline" style="underline"/>
+  <entry type="Text" style="#4D4D4C"/>
+  <entry type="TextWhitespace" style="#4D4D4C"/>
+  <entry type="Other" style="#4D4D4C"/>
+</style>


### PR DESCRIPTION
This introduces a chroma implementation of the popular Tomorrow theme. The original implementation and theme definition lives at: https://github.com/chriskempson/tomorrow-theme

The theme includes a few variations on the colour palette, which results in 4 'dark' themes and one 'light' theme.

* `tomorrow-night-blue`
* `tomorrow-night-bright`
* `tomorrow-night-eighties`
* `tomorrow-night`
* `tomorrow`
