### PR TITLE
html: Emit all token rules with WithAllClasses(true)

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -548,7 +548,10 @@ func (f *Formatter) styleToCSS(style *chroma.Style) map[chroma.TokenType]string 
 	// Convert the style.
 	for t := range chroma.StandardTypes {
 		entry := style.Get(t)
-		if t != chroma.Background {
+		// With allClasses, keep the fully resolved entry so every token's
+		// rule is materialised explicitly rather than relying on the CSS
+		// cascade from the wrapper class.
+		if t != chroma.Background && !f.allClasses {
 			entry = entry.Sub(bg)
 		}
 

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -449,6 +449,16 @@ func TestWriteCssWithAllClasses(t *testing.T) {
 	assert.NotContains(t, buf.String(), ".chroma . {", "Generated css doesn't contain invalid css")
 }
 
+func TestWriteCssWithAllClassesGithubDark(t *testing.T) {
+	formatter := New(WithAllClasses(true))
+
+	var buf bytes.Buffer
+	err := formatter.WriteCSS(&buf, styles.Get("github-dark"))
+
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), ".chroma .nx")
+}
+
 func TestModeClassOnWrapper(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
The empty-rule guard added in 5b2a4c5 silently dropped tokens whose
style was reduced to nothing by the Sub(bg) normalisation.

This is now in line with the comment on WriteCSS.
