### PR TITLE
fix(lexers): don't read past the end on an unterminated Raku comment

### DIFF
--- a/lexers/raku.go
+++ b/lexers/raku.go
@@ -561,10 +561,21 @@ func rakuRules() Rules {
 					}
 				}
 			default:
-				state.Groups = []string{state.Groups[0] + string(text[state.Pos:endPos+nChars])}
+				// If no closing delimiter was found, endPos is already
+				// len(text); don't also add nChars on top of that, or
+				// we'd read past the end of the input (same guard as
+				// the heredoc-terminator handling above).
+				commentEnd := endPos + nChars
+				if commentEnd > len(text) {
+					commentEnd = len(text)
+				}
+				state.Groups = []string{state.Groups[0] + string(text[state.Pos:commentEnd])}
 			}
 
 			state.Pos = endPos + nChars
+			if state.Pos > len(text) {
+				state.Pos = len(text)
+			}
 
 			return nil
 		}

--- a/lexers/raku.go
+++ b/lexers/raku.go
@@ -565,17 +565,11 @@ func rakuRules() Rules {
 				// len(text); don't also add nChars on top of that, or
 				// we'd read past the end of the input (same guard as
 				// the heredoc-terminator handling above).
-				commentEnd := endPos + nChars
-				if commentEnd > len(text) {
-					commentEnd = len(text)
-				}
+				commentEnd := min(endPos+nChars, len(text))
 				state.Groups = []string{state.Groups[0] + string(text[state.Pos:commentEnd])}
 			}
 
-			state.Pos = endPos + nChars
-			if state.Pos > len(text) {
-				state.Pos = len(text)
-			}
+			state.Pos = min(endPos+nChars, len(text))
 
 			return nil
 		}

--- a/lexers/testdata/raku/unterminated_comment.actual
+++ b/lexers/testdata/raku/unterminated_comment.actual
@@ -1,0 +1,1 @@
+#`(((unterminated

--- a/lexers/testdata/raku/unterminated_comment.expected
+++ b/lexers/testdata/raku/unterminated_comment.expected
@@ -1,0 +1,3 @@
+[
+  {"type":"CommentMultiline","value":"#`(((unterminated\n"}
+]


### PR DESCRIPTION
## What's broken

An unterminated bracketed Raku comment reads past the end of the input, and panics when the slice has no spare capacity.

```
lexers.Get("raku").Tokenise(nil, "#`(((unterminated")
-> CommentMultiline "#`(((unterminated\x00\x00\x00"
```

Three NUL runes, matching the three-character opening delimiter. On an exactly-sized slice the same overshoot panics instead:

```
panic: runtime error: slice bounds out of range [:21] with capacity 20
```

## The fix

When no closing bracket is found, `endPos` is already `len(text)`, but `nChars` still holds the count from the nesting loop, so `endPos+nChars` overshoots.

The heredoc branch about forty lines above already guards this, clamping `endPos` and resetting `nChars` when the terminator is missing. This clamps the comment slice the same way. For a properly terminated comment `endPos+nChars` is already in bounds, so the clamp is a no-op and nothing changes.

`state.Pos = endPos + nChars` on the next line has the same overshoot. It cannot panic today because the reader loop in `regexp.go` is guarded by `for l.Pos < end`, but it leaves `state.Pos` past the end of the text, so it is clamped too.

## Verification

`lexers/testdata/raku/unterminated_comment.actual` and its golden, alongside the existing `unterminated_heredoc` pair. The `.expected` was generated with `RECORD=true go test`, not written by hand. Note that a brand new `.expected` has to exist as an empty file first, since `assert.NoError` on the read halts the subtest before the RECORD branch runs.

With the clamp reverted the new test panics on the out-of-range slice above, so it is testing the real failure. `go test ./lexers/...` passes.
