### PR TITLE
fix(svg): non-ASCII text misaligns token background rects

### DIFF
--- a/formatters/svg/svg.go
+++ b/formatters/svg/svg.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/alecthomas/chroma/v3"
 )
@@ -134,12 +135,17 @@ func (f *Formatter) writeSVG(w io.Writer, style *chroma.Style, tokens []chroma.T
 	return err
 }
 
+// tokenWidth is the token's width in character cells, with tabs expanded.
+func tokenWidth(token chroma.Token) int {
+	return utf8.RuneCountInString(strings.ReplaceAll(token.String(), `	`, "    "))
+}
+
 func maxLineWidth(lines [][]chroma.Token) int {
 	maxWidth := 0
 	for _, tokens := range lines {
 		length := 0
 		for _, token := range tokens {
-			length += len(strings.ReplaceAll(token.String(), `	`, "    "))
+			length += tokenWidth(token)
 		}
 		if length > maxWidth {
 			maxWidth = length
@@ -155,7 +161,7 @@ func (f *Formatter) writeTokenBackgrounds(w io.Writer, lines [][]chroma.Token, s
 	for index, tokens := range lines {
 		lineLength := 0
 		for _, token := range tokens {
-			length := len(strings.ReplaceAll(token.String(), `	`, "    "))
+			length := tokenWidth(token)
 			tokenBackground := style.Get(token.Type).Background
 			if tokenBackground.IsSet() && tokenBackground != style.Get(chroma.Background).Background {
 				if _, err := fmt.Fprintf(w, "<rect id=\"%s\" x=\"%dch\" y=\"%fem\" width=\"%dch\" height=\"1.2em\" fill=\"%s\" />\n", escapeString(token.String()), lineLength, 1.2*float64(index)+0.25, length, style.Get(token.Type).Background.String()); err != nil {

--- a/formatters/svg/svg_test.go
+++ b/formatters/svg/svg_test.go
@@ -4,8 +4,35 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/chroma/v3"
+
 	assert "github.com/alecthomas/assert/v2"
 )
+
+func TestNonASCIIWidths(t *testing.T) {
+	style, err := chroma.NewStyle("test", chroma.StyleEntries{
+		chroma.Background:    "#ffffff bg:#ffffff",
+		chroma.LiteralString: "bg:#fff0f0",
+	})
+	assert.NoError(t, err)
+
+	tokens := []chroma.Token{
+		{Type: chroma.Text, Value: "x = "},
+		{Type: chroma.LiteralString, Value: `"éé"`},
+		{Type: chroma.Text, Value: ", "},
+		{Type: chroma.LiteralString, Value: `"ab"`},
+		{Type: chroma.Text, Value: "\n"},
+	}
+
+	w := &strings.Builder{}
+	assert.NoError(t, New().Format(w, style, chroma.Literator(tokens...)))
+	out := w.String()
+
+	// Widths and offsets are in character cells, so multi-byte runes count once.
+	assert.Contains(t, out, `<svg width="120px"`)
+	assert.Contains(t, out, `x="4ch" y="0.250000em" width="4ch"`)
+	assert.Contains(t, out, `x="10ch" y="0.250000em" width="4ch"`)
+}
 
 func TestWriteFontStyle(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
The SVG formatter measures line widths in bytes rather than characters, so any non-ASCII rune inflates the canvas and pushes token background rects out of alignment with the text they sit behind.

Tokenising `x = ["éé", "ab"]` with a style that sets a string background:

```
before: <svg width="136px" ...>
        <rect id="&quot;éé&quot;" x="4ch"  ... width="6ch" />
        <rect id="&quot;ab&quot;" x="12ch" ... width="4ch" />

after:  <svg width="120px" ...>
        <rect id="&quot;éé&quot;" x="4ch"  ... width="4ch" />
        <rect id="&quot;ab&quot;" x="10ch" ... width="4ch" />
```

`"éé"` is 4 characters and 6 bytes. The old code gives its rect a width of 6 cells, then starts the next rect 2 cells too far right, so the `"ab"` highlight is visibly offset from `"ab"`. Every token after the first non-ASCII one on a line inherits that drift, and the `<svg width>` is overstated by the same amount.

`x` and `width` are emitted in `ch` units, which are character cells in a monospace font, so the count has to be in runes.

## The fix

`maxLineWidth` and `writeTokenBackgrounds` computed the same expression with `len()`. Extracted it as `tokenWidth` using `utf8.RuneCountInString`, keeping the existing tab expansion.

Pure-ASCII output is unchanged. Rendering `lexer.go` from this repo to SVG before and after gives byte-identical files.

## Verification

`TestNonASCIIWidths` in `formatters/svg/svg_test.go` builds a style with a string background so the rect path is exercised, then asserts the canvas width and both rect offsets.

Reverting `svg.go` fails it, and the failure output shows the misalignment directly:

```
Needle:   <svg width="120px"
Haystack: ... <svg width="136px" ...
          <rect id="&quot;éé&quot;" x="4ch" ... width="6ch" ... />
          <rect id="&quot;ab&quot;" x="12ch" ... width="4ch" ... />
```

`go test ./...` passes and `golangci-lint run` is clean.

*Disclosure: written with AI assistance (Claude Code). I produced the before and after by rendering real files through both builds, and ran the revert check myself.*
