### PR TITLE
fix(cmd/chroma): the module does not build at HEAD

### DIFF
--- a/cmd/chroma/go.mod
+++ b/cmd/chroma/go.mod
@@ -12,6 +12,6 @@ require (
 )
 
 require (
-	github.com/dlclark/regexp2/v2 v2.5.2 // indirect
+	github.com/dlclark/regexp2/v2 v2.7.1 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 )

--- a/cmd/chroma/go.sum
+++ b/cmd/chroma/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/kong v1.16.1 h1:ixhCt93XkJ98kGposQ54+bl0IK6XwqB40AsMynU7Z8
 github.com/alecthomas/kong v1.16.1/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.4 h1:OVP7JEcuzU9CCDsT6STCr3rg17oQfWILtPWd2EG0uN4=
 github.com/alecthomas/repr v0.5.4/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/dlclark/regexp2/v2 v2.5.2 h1:HAsucWRhsqcDzl6Ua9aR8JwYOTzrZyPrF0/FNxJVAI0=
-github.com/dlclark/regexp2/v2 v2.5.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dlclark/regexp2/v2 v2.7.1 h1:yqDtwI1ptXXvEUNpYTk2lad4jLtAcKqkzepn4savSk4=
+github.com/dlclark/regexp2/v2 v2.7.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy0/jY=


### PR DESCRIPTION
`cmd/chroma` does not build at HEAD.

```
$ cd cmd/chroma && go build ./...
go: updates to go.mod needed; to update it:
	go mod tidy
```

`cmd/chroma` is a separate module with a `replace` pointing at the repo root, and the root now requires `regexp2/v2 v2.7.1` while `cmd/chroma/go.mod` still pins the indirect dependency at `v2.5.2`. Since the `replace` pulls the root's requirement in, the two disagree and the module refuses to build.

This is the output of `go mod tidy`, nothing hand-edited: one indirect version line plus the corresponding `go.sum` entries.

Worth noting that root CI does not catch this, because the workflow runs `go test ./...` and `golangci-lint run` from the repository root, and `cmd/chroma` is outside that module. `golangci-lint` inside `cmd/chroma` currently cannot load the package at all for the same reason:

```
no go files to analyze: running `go mod tidy` may solve the problem
```

After this change both `go build ./...` and `go test ./...` in `cmd/chroma` succeed.

I am sending this on its own rather than folding it into the CLI fix that made me notice it, since it stands alone and unblocks anything else touching that module.

*Disclosure: written with AI assistance (Claude Code). I confirmed the failure on an unmodified checkout of master, so it is not something my other changes introduced.*
