### PR TITLE
fix(cmd/chroma): --html-styles ignores the other --html-* flags

### DIFF
--- a/cmd/chroma/go.mod
+++ b/cmd/chroma/go.mod
@@ -12,6 +12,6 @@ require (
 )
 
 require (
-	github.com/dlclark/regexp2/v2 v2.5.2 // indirect
+	github.com/dlclark/regexp2/v2 v2.7.1 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 )

--- a/cmd/chroma/go.sum
+++ b/cmd/chroma/go.sum
@@ -4,8 +4,8 @@ github.com/alecthomas/kong v1.16.1 h1:ixhCt93XkJ98kGposQ54+bl0IK6XwqB40AsMynU7Z8
 github.com/alecthomas/kong v1.16.1/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/repr v0.5.4 h1:OVP7JEcuzU9CCDsT6STCr3rg17oQfWILtPWd2EG0uN4=
 github.com/alecthomas/repr v0.5.4/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/dlclark/regexp2/v2 v2.5.2 h1:HAsucWRhsqcDzl6Ua9aR8JwYOTzrZyPrF0/FNxJVAI0=
-github.com/dlclark/regexp2/v2 v2.5.2/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
+github.com/dlclark/regexp2/v2 v2.7.1 h1:yqDtwI1ptXXvEUNpYTk2lad4jLtAcKqkzepn4savSk4=
+github.com/dlclark/regexp2/v2 v2.7.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy0/jY=

--- a/cmd/chroma/main.go
+++ b/cmd/chroma/main.go
@@ -215,7 +215,7 @@ func main() {
 	style, err := builder.Build()
 	ctx.FatalIfErrorf(err)
 
-	if cli.Formatter == "html" {
+	if usesHTMLFormatter() {
 		configureHTMLFormatter(ctx)
 	}
 
@@ -294,6 +294,13 @@ func selectStyle() (*chroma.Style, error) {
 	}
 	defer r.Close()
 	return chroma.NewXMLStyle(r)
+}
+
+// usesHTMLFormatter reports whether the html formatter will be used.
+// --html-styles dumps its CSS regardless of the selected formatter, so the
+// html options have to be applied for it too.
+func usesHTMLFormatter() bool {
+	return cli.Formatter == "html" || cli.HTMLStyles
 }
 
 func configureHTMLFormatter(ctx *kong.Context) {

--- a/cmd/chroma/main_test.go
+++ b/cmd/chroma/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/kong"
+
+	"github.com/alecthomas/chroma/v3/formatters"
+	"github.com/alecthomas/chroma/v3/formatters/html"
+	"github.com/alecthomas/chroma/v3/styles"
+)
+
+// --html-styles dumps CSS from the html formatter even when the selected
+// formatter is something else, so the html options must still apply.
+func TestHTMLStylesAppliesHTMLOptions(t *testing.T) {
+	saved := cli
+	t.Cleanup(func() {
+		cli = saved
+		formatters.Register("html", html.New(html.Standalone(true), html.WithClasses(true)))
+	})
+
+	cli.Formatter = "terminal"
+	cli.HTMLStyles = true
+	cli.HTMLPrefix = "pfx-"
+	cli.HTMLTabWidth = 4
+
+	if !usesHTMLFormatter() {
+		t.Fatal("expected html formatter to be in use")
+	}
+	configureHTMLFormatter(&kong.Context{})
+
+	w := &strings.Builder{}
+	if err := formatters.Get("html").(*html.Formatter).WriteCSS(w, styles.Fallback); err != nil {
+		t.Fatal(err)
+	}
+	out := w.String()
+	if !strings.Contains(out, ".pfx-chroma") {
+		t.Errorf("--html-prefix not applied:\n%s", out)
+	}
+	if !strings.Contains(out, "tab-size: 4") {
+		t.Errorf("--html-tab-width not applied:\n%s", out)
+	}
+}


### PR DESCRIPTION
Stacked on #1347, which is needed for `cmd/chroma` to build at all.

`--html-styles` ignores every other `--html-*` flag.

```
$ chroma --html-styles --html-prefix=foo- --html-tab-width=4 | head -2
/* Background */ .bg { color: #e5e5e5; background-color: #000000; }
/* PreWrapper */ .chroma { color: #e5e5e5; background-color: #000000; -webkit-text-size-adjust: none; }
```

After:

```
/* Background */ .foo-bg { color: #e5e5e5; background-color: #000000;tab-size: 4; }
/* PreWrapper */ .foo-chroma { color: #e5e5e5; background-color: #000000;tab-size: 4; -webkit-text-size-adjust: none; }
```

Generating a stylesheet is exactly when `--html-prefix` matters most, since the prefix has to agree with whatever generated the HTML. Emitting unprefixed CSS produces a stylesheet that silently matches nothing.

## Cause

```go
if cli.Formatter == "html" {
	configureHTMLFormatter(ctx)
}
```

but `--html-styles` writes CSS from the html formatter regardless of which formatter is selected. So unless you also pass `-f html`, which is pointless when you only want the stylesheet, the html options are never applied.

Same for `--html-lines-table`, `--html-highlight`, `--html-linkable-lines` and the rest of the group.

## The fix

A small `usesHTMLFormatter()` covering both cases, at the one call site.

Unchanged, checked before and after: `-f html --html-prefix=zz-` still emits `zz-chroma`, and a bare `--html-styles` with no other flags is byte-identical.

## Verification

`TestHTMLStylesAppliesHTMLOptions` in `cmd/chroma/main_test.go` sets `cli.Formatter = "terminal"` with `--html-styles`, `--html-prefix` and `--html-tab-width`, then asserts both appear in the CSS.

Reverting the condition to `cli.Formatter == "html"` fails it:

```
--- FAIL: TestHTMLStylesAppliesHTMLOptions
    main_test.go:29: expected html formatter to be in use
```

`go test ./...` passes in both the root module and `cmd/chroma`, and `golangci-lint run` at the root is clean.

*Disclosure: written with AI assistance (Claude Code). I built both binaries, produced the before and after above by running them, and ran the revert check myself.*
