### PR TITLE
fix(lexers): the Markless supertext rule was unreachable

### DIFF
--- a/lexers/markless.go
+++ b/lexers/markless.go
@@ -102,7 +102,7 @@ func marklessRules() Rules {
 			Include("compound"),
 			Include("footnote-reference"),
 			Include("subtext"),
-			Include("subtext"),
+			Include("supertext"),
 			Include("url"),
 			{`.`, Text, nil},
 			{`\n`, TextWhitespace, Pop(1)},

--- a/lexers/testdata/markless.actual
+++ b/lexers/testdata/markless.actual
@@ -43,3 +43,5 @@ The Markless document standard and ecosystem is brought to you by the ''Shirakum
 
 1. First things first, this <-is great->
 10. Now for something different.
+
+The formula is H v(2) O, and the area is 4 ^(2) cm.

--- a/lexers/testdata/markless.expected
+++ b/lexers/testdata/markless.expected
@@ -161,5 +161,15 @@
   {"type":"Keyword","value":"10."},
   {"type":"TextWhitespace","value":" "},
   {"type":"Text","value":"Now for something different."},
+  {"type":"TextWhitespace","value":"\n\n"},
+  {"type":"Text","value":"The formula is H "},
+  {"type":"Keyword","value":"v("},
+  {"type":"Text","value":"2"},
+  {"type":"Keyword","value":")"},
+  {"type":"Text","value":" O, and the area is 4 "},
+  {"type":"Keyword","value":"^("},
+  {"type":"Text","value":"2"},
+  {"type":"Keyword","value":")"},
+  {"type":"Text","value":" cm."},
   {"type":"TextWhitespace","value":"\n"}
 ]


### PR DESCRIPTION
The Markless `inline` state includes `subtext` twice, so the `supertext` rule right below it is defined but never reachable. Superscript markup comes out as plain text.

```go
Include("subtext"),
Include("subtext"),   // <- this should be supertext
```

Tokenising `Water is H v(2) O and E = mc ^(2) here.`:

```
before:  Text     "Water is H "
         Keyword  "v("
         Text     "2"
         Keyword  ")"
         Text     " O and E = mc ^(2) here."

after:   Text     "Water is H "
         Keyword  "v("
         Text     "2"
         Keyword  ")"
         Text     " O and E = mc "
         Keyword  "^("
         Text     "2"
         Keyword  ")"
         Text     " here."
```

Subscript already worked, which is why it went unnoticed: the duplicated include still made `v(...)` highlight, so only the superscript half was silently dead.

## The fix

One line. The rule itself, `{`(\^\()(.*?)(\))`, ByGroups(...)}`, is unchanged and was already written correctly; it just had no way in.

## Verification

A superscript case added to `lexers/testdata/markless.actual`, with `markless.expected` regenerated via `RECORD=true go test ./lexers/`, which is the mechanism documented in `lexers_test.go`. The diff to the expected file is append-only, so nothing else re-tokenised.

Reverting only line 105 back to `Include("subtext")` fails it:

```
--- FAIL: TestLexers/Markless/testdata/markless.actual
    -  {"type":"Text","value":" O, and the area is 4 "},
    -  {"type":"Keyword","value":"^("},
    -  {"type":"Text","value":"2"},
    -  {"type":"Keyword","value":")"},
    +  {"type":"Text","value":" O, and the area is 4 ^(2) cm."},
```

`go build ./...`, `go test ./...`, `gofmt -l` and `golangci-lint run ./lexers/` are all clean.

*Disclosure: written with AI assistance (Claude Code). I ran the tokeniser before and after, regenerated the fixture with the documented RECORD mechanism, and ran the mutation check myself.*
