### PR TITLE
fix: four lexers push onto states that do not exist

### DIFF
--- a/lexers/embedded/psl.xml
+++ b/lexers/embedded/psl.xml
@@ -164,6 +164,11 @@
         <token type="CommentSingle"/>
       </rule>
     </state>
+    <state name="warn-directive">
+      <rule pattern=".+$">
+        <token type="CommentSingle"/>
+      </rule>
+    </state>
     <state name="classdef-directive">
       <rule pattern="\s+">
         <token type="Text"/>

--- a/lexers/embedded/sourcepawn.xml
+++ b/lexers/embedded/sourcepawn.xml
@@ -31,8 +31,6 @@
       <rule pattern="(bool|float|void|int|char)\b"><token type="KeywordType"/></rule>
       <rule pattern="(true|false)\b"><token type="KeywordConstant"/></rule>
       <rule pattern="[a-zA-Z_]\w*"><token type="Name"/></rule>
-      <rule pattern="((?:[\w*\s])+?(?:\s|[*]))([a-zA-Z_]\w*)(\s*\([^;]*?\))([^;{]*)(\{)"><bygroups><usingself state="root"/><token type="NameFunction"/><usingself state="root"/><usingself state="root"/><token type="Punctuation"/></bygroups><push state="function"/></rule>
-      <rule pattern="((?:[\w*\s])+?(?:\s|[*]))([a-zA-Z_]\w*)(\s*\([^;]*?\))([^;]*)(;)"><bygroups><usingself state="root"/><token type="NameFunction"/><usingself state="root"/><usingself state="root"/><token type="Punctuation"/></bygroups></rule>
     </state>
     <state name="string">
       <rule pattern="&quot;"><token type="LiteralString"/><pop depth="1"/></rule>

--- a/lexers/embedded/spade.xml
+++ b/lexers/embedded/spade.xml
@@ -20,6 +20,14 @@
         <pop depth="1"/>
       </rule>
     </state>
+    <state name="lifetime">
+      <rule pattern="[a-zA-Z_]+\w*">
+        <token type="NameAttribute"/>
+      </rule>
+      <rule>
+        <pop depth="1"/>
+      </rule>
+    </state>
     <state name="number_lit">
       <rule pattern="[ui]\d*">
         <token type="Keyword"/>

--- a/lexers/embedded/yang.xml
+++ b/lexers/embedded/yang.xml
@@ -85,7 +85,7 @@
       </rule>
       <rule pattern="/\*">
         <token type="CommentMultiline"/>
-        <push state="comment"/>
+        <push/>
       </rule>
       <rule pattern="\*/">
         <token type="CommentMultiline"/>

--- a/lexers/testdata/psl.actual
+++ b/lexers/testdata/psl.actual
@@ -17,3 +17,5 @@ public Number SumMethod() {
     do finishTask(x, "AAA")
 
     quit
+    #WARN unused variable
+    #INFO informational

--- a/lexers/testdata/psl.expected
+++ b/lexers/testdata/psl.expected
@@ -148,5 +148,12 @@
   {"type":"LiteralString","value":"\"AAA\""},
   {"type":"Punctuation","value":")"},
   {"type":"Text","value":"\n\n    "},
-  {"type":"Keyword","value":"quit"}
+  {"type":"Keyword","value":"quit"},
+  {"type":"Text","value":"\n    "},
+  {"type":"KeywordPseudo","value":"#WARN"},
+  {"type":"CommentSingle","value":" unused variable"},
+  {"type":"Text","value":"\n    "},
+  {"type":"KeywordPseudo","value":"#INFO"},
+  {"type":"CommentSingle","value":" informational"},
+  {"type":"Text","value":"\n"}
 ]

--- a/lexers/testdata/spade.actual
+++ b/lexers/testdata/spade.actual
@@ -184,3 +184,7 @@ fn named_args() {
 	call$(a, b: true)
 }
 
+
+type T {
+    x: 'a int,
+}

--- a/lexers/testdata/spade.expected
+++ b/lexers/testdata/spade.expected
@@ -1085,5 +1085,20 @@
   {"type":"Punctuation","value":")"},
   {"type":"TextWhitespace","value":"\n"},
   {"type":"Punctuation","value":"}"},
-  {"type":"TextWhitespace","value":"\n\n"}
+  {"type":"TextWhitespace","value":"\n\n\n"},
+  {"type":"Name","value":"type"},
+  {"type":"TextWhitespace","value":" "},
+  {"type":"Name","value":"T"},
+  {"type":"TextWhitespace","value":" "},
+  {"type":"Punctuation","value":"{"},
+  {"type":"TextWhitespace","value":"\n    "},
+  {"type":"Name","value":"x"},
+  {"type":"Text","value":": "},
+  {"type":"NameAttribute","value":"'a"},
+  {"type":"Text","value":" "},
+  {"type":"KeywordType","value":"int"},
+  {"type":"Punctuation","value":","},
+  {"type":"TextWhitespace","value":"\n"},
+  {"type":"Punctuation","value":"}"},
+  {"type":"TextWhitespace","value":"\n"}
 ]

--- a/lexers/testdata/yang.actual
+++ b/lexers/testdata/yang.actual
@@ -62,3 +62,5 @@ module server-system {
         }
     }
 }
+
+/* nested /* comment */ still comment */

--- a/lexers/testdata/yang.expected
+++ b/lexers/testdata/yang.expected
@@ -216,5 +216,7 @@
   {"type":"Punctuation","value":"}"},
   {"type":"TextWhitespace","value":"\n"},
   {"type":"Punctuation","value":"}"},
+  {"type":"TextWhitespace","value":"\n\n"},
+  {"type":"CommentMultiline","value":"/* nested /* comment */ still comment */"},
   {"type":"TextWhitespace","value":"\n"}
 ]

--- a/mutators.go
+++ b/mutators.go
@@ -18,6 +18,14 @@ type SerialisableMutator interface {
 	MutatorKind() string
 }
 
+// ValidatingMutator is a Mutator that can validate itself against the compiled rules.
+//
+// Validation occurs once, after all LexerMutators have been applied.
+type ValidatingMutator interface {
+	Mutator
+	ValidateMutator(rules CompiledRules) error
+}
+
 // A LexerMutator is an additional interface that a Mutator can implement
 // to modify the lexer when it is compiled.
 type LexerMutator interface {
@@ -70,6 +78,17 @@ func (m *multiMutator) MarshalXML(e *xml.Encoder, start xml.StartElement) error 
 }
 
 func (m *multiMutator) MutatorKind() string { return "mutators" }
+
+func (m *multiMutator) ValidateMutator(rules CompiledRules) error {
+	for _, mutator := range m.Mutators {
+		if validate, ok := mutator.(ValidatingMutator); ok {
+			if err := validate.ValidateMutator(rules); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
 
 func (m *multiMutator) Mutate(state *LexerState) error {
 	for _, modifier := range m.Mutators {
@@ -145,7 +164,24 @@ type pushMutator struct {
 	States []string `xml:"state,attr"`
 }
 
+var (
+	_ ValidatingMutator = (*pushMutator)(nil)
+	_ ValidatingMutator = (*multiMutator)(nil)
+)
+
 func (p *pushMutator) MutatorKind() string { return "push" }
+
+func (p *pushMutator) ValidateMutator(rules CompiledRules) error {
+	for _, state := range p.States {
+		if state == "#pop" {
+			continue
+		}
+		if _, ok := rules[state]; !ok {
+			return fmt.Errorf("invalid push state %q", state)
+		}
+	}
+	return nil
+}
 
 func (p *pushMutator) Mutate(s *LexerState) error {
 	if len(p.States) == 0 {

--- a/regexp.go
+++ b/regexp.go
@@ -392,12 +392,17 @@ restart:
 			}
 		}
 	}
-	// Validate emitters
+	// Validate emitters and mutators
 	for state := range r.rules {
 		for i := range len(r.rules[state]) {
 			rule := r.rules[state][i]
 			if validate, ok := rule.Type.(ValidatingEmitter); ok {
 				if err := validate.ValidateEmitter(rule); err != nil {
+					return fmt.Errorf("%s: %s: %s: %w", r.config.Name, state, rule.Pattern, err)
+				}
+			}
+			if validate, ok := rule.Mutator.(ValidatingMutator); ok {
+				if err := validate.ValidateMutator(r.rules); err != nil {
 					return fmt.Errorf("%s: %s: %s: %w", r.config.Name, state, rule.Pattern, err)
 				}
 			}

--- a/regexp_test.go
+++ b/regexp_test.go
@@ -216,3 +216,30 @@ func TestIgnoreToken(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []Token{{Keyword, "hello"}, {TextWhitespace, "\n"}}, slices.Collect(it))
 }
+
+func TestPushToUndefinedStateIsAnError(t *testing.T) {
+	lexer, err := NewLexer(&Config{Name: "test"}, func() Rules {
+		return Rules{
+			"root": {
+				{`a`, Text, Push("nonexistent")},
+			},
+		}
+	})
+	assert.NoError(t, err)
+	_, err = lexer.Tokenise(nil, "a")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid push state "nonexistent"`)
+
+	// #pop is a valid pseudo-state and must not be rejected.
+	lexer = mustNewLexer(t, &Config{Name: "test"}, Rules{ // nolint: forbidigo
+		"root": {
+			{`a`, Text, Push("other")},
+		},
+		"other": {
+			{`b`, Text, Push("#pop")},
+		},
+	})
+	it, err := lexer.Tokenise(nil, "ab")
+	assert.NoError(t, err)
+	assert.Equal(t, []Token{{Text, "a"}, {Text, "b"}}, slices.Collect(it))
+}


### PR DESCRIPTION
Four lexers push onto states that do not exist, so lexing ordinary input for
those languages fails at runtime.

```
$ chroma -f noop --lexer yang  file    # /* nested */ comment
before: chroma: error: unknown state comment
after:  /* outer /* inner */ */

$ chroma -f noop --lexer psl   file    # #WARN directive
before: chroma: error: unknown state warn-directive
after:  #WARN something

$ chroma -f noop --lexer spade file    # a lifetime
before: chroma: error: unknown state lifetime
after:  fn f(x: 'a) {}
```

## The fix, and why it is one change rather than four

The root cause is that a `push` onto a missing state is only discovered when a
document happens to reach that rule. `regexp.go` already validates emitters at
compile time; this adds the same for mutators, via a `ValidatingMutator`
interface implemented by `pushMutator` and `multiMutator`. A bad push then fails
when the lexer is compiled, which the existing `TestCompileAllRegexes` runs over
every lexer in the repo.

Turning that on is what surfaces the four broken lexers, and they have to be
fixed in the same commit or the suite goes red. Reverting just the four XML files
with the validation in place gives:

```
--- FAIL: TestCompileAllRegexes
        PSL: directive: INFO|WARN: invalid push state "warn-directive"
--- FAIL: TestLexers/PSL/testdata/psl.actual
--- FAIL: TestLexers/SourcePawn/testdata/sourcepawn.actual
```

The four:

- **yang**: `push state="comment"` inside the `comment` state itself, for nested
  block comments. Changed to `<push/>` (`#push`), which is what Pygments does.
- **psl**: the `#WARN`/`#INFO` rule pushes `warn-directive`, which was never
  defined. Added, mirroring the sibling `other-directive` and
  `accept-directive` states.
- **spade**: pushes `lifetime`, never defined. Added, copied from `rust.xml`,
  which Spade derives from.
- **sourcepawn**: two rules push a nonexistent `function` state. Both are also
  unreachable, shadowed by the preceding `[a-zA-Z_]\w*` rule, and upstream
  Pygments has no such rules, so I removed them rather than invent a state.
  `sourcepawn.expected` is unchanged, which is the evidence they never fired.

## Verification

`TestPushToUndefinedStateIsAnError` compiles a lexer that pushes a missing state
and expects an error.

Removing the validation block from `regexp.go` fails it:

```
--- FAIL: TestPushToUndefinedStateIsAnError
    regexp_test.go:230: Expected an error
```

Reverting `yang.xml` back to `<push state="comment"/>` fails the golden test with
the new compile-time message rather than a runtime one:

```
--- FAIL: TestLexers/YANG/testdata/yang.actual
        YANG: comments: /\*: invalid push state "comment"
```

Changing the spade `lifetime` token to `Text` fails on the token stream:

```
- {"type":"NameAttribute","value":"'a"}
+ {"type":"NameAttribute","value":"'"}
```

The `psl`, `spade` and `yang` goldens are regenerated with `RECORD=true` after
appending a snippet that exercises each fixed path.

`go test ./...` is ok across every package, and `golangci-lint run ./...` exits
0.

One judgement call worth flagging: PSL is not a Pygments lexer, so
`warn-directive` had no upstream reference. I gave it the same `.+$` to
`CommentSingle` body as its sibling directive states, which is what the original
author's rule clearly intended, but you may prefer different content.

*Disclosure: written with AI assistance (Claude Code). The before and after come from running the real `chroma` binary from each tree, and I ran the mutation checks and the coupling check above myself.*
