### PR TITLE
fix(lexers): markdown code spans and strikethrough match across a blank line

### DIFF
--- a/lexers/markdown.go
+++ b/lexers/markdown.go
@@ -98,8 +98,10 @@ func markdownRules() Rules {
 			{`\\.`, Text, nil},
 			{`(\s)(\*|_)((?:(?!\2).)*)(\2)((?=\W|\n))`, ByGroups(Text, GenericEmph, GenericEmph, GenericEmph, Text), nil},
 			{`(\s)((\*\*|__).*?)\3((?=\W|\n))`, ByGroups(Text, GenericStrong, GenericStrong, Text), nil},
-			{`(\s)(~~[^~]+~~)((?=\W|\n))`, ByGroups(Text, GenericDeleted, Text), nil},
-			{"`[^`]+`", LiteralStringBacktick, nil},
+			{`(\s)(~~(?:[^~\n]|\n(?![ \t]*\n))+~~)((?=\W|\n))`, ByGroups(Text, GenericDeleted, Text), nil},
+			// A code span may contain line endings but not a blank line, which
+			// terminates the enclosing paragraph (CommonMark 6.1 "Code spans").
+			{"`(?:[^`\\n]|\\n(?![ \\t]*\\n))+`", LiteralStringBacktick, nil},
 			{`[@#][\w/:]+`, NameEntity, nil},
 			{`(!?\[)([^]]+)(\])(\()([^)]+)(\))`, ByGroups(Text, NameTag, Text, Text, NameAttribute, Text), nil},
 			{`.|\n`, Text, nil},

--- a/lexers/testdata/markdown.actual
+++ b/lexers/testdata/markdown.actual
@@ -110,3 +110,23 @@ Text after a horizontal rule.
   [whitespace before link](https://google.com)  
 abc[non-whitespace before link](https://google.com)  
 ([first link](https://google.com) and [second link](https://google.com))  
+
+## Code span does not cross a blank line
+
+here is `an open span
+
+## Swallowed Header
+
+and it closes` here.
+
+a `span wrapped
+across one line break` still lexes.
+
+open ~~strikethrough
+
+## Not Struck Header
+
+close~~ here.
+
+a ~~struck across one
+line break~~ still lexes.

--- a/lexers/testdata/markdown.expected
+++ b/lexers/testdata/markdown.expected
@@ -468,5 +468,15 @@
   {"type":"NameTag","value":"second link"},
   {"type":"Text","value":"]("},
   {"type":"NameAttribute","value":"https://google.com"},
-  {"type":"Text","value":"))  \n"}
+  {"type":"Text","value":"))  \n\n"},
+  {"type":"GenericSubheading","value":"## Code span does not cross a blank line\n"},
+  {"type":"Text","value":"\nhere is `an open span\n\n"},
+  {"type":"GenericSubheading","value":"## Swallowed Header\n"},
+  {"type":"Text","value":"\nand it closes` here.\n\na "},
+  {"type":"LiteralStringBacktick","value":"`span wrapped\nacross one line break`"},
+  {"type":"Text","value":" still lexes.\n\nopen ~~strikethrough\n\n"},
+  {"type":"GenericSubheading","value":"## Not Struck Header\n"},
+  {"type":"Text","value":"\nclose~~ here.\n\na "},
+  {"type":"GenericDeleted","value":"~~struck across one\nline break~~"},
+  {"type":"Text","value":" still lexes.\n"}
 ]


### PR DESCRIPTION
## What's broken

An unclosed backtick span swallows everything up to the next backtick anywhere in the document, including headers, which lose their highlighting. Reported in #1325.

## Repro

```
$ chroma --lexer markdown --formatter tokens
here is `an open span

## Swallowed Header

and it closes`

before:
  Token{Text, "here is "}
  Token{LiteralStringBacktick, "`an open span\n\n## Swallowed Header\n\nand it closes`"}

after:
  Token{Text, "here is `an open span\n\n"}
  Token{GenericSubheading, "## Swallowed Header\n"}
```

## The fix

The rule was `` `[^`]+` ``, and the negated class matches newlines, so the span could run through blank lines. A blank line ends the paragraph, so a code span cannot cross one (CommonMark 6.1). The rule now allows a line ending but not a blank one.

`~~strikethrough~~` had the same root cause, so it is fixed in the same way. `*emph*` and `**strong**` already scope correctly, so I left them alone.

## Verification

Two cases added to `testdata/markdown.actual`, one per rule. Reverting each rule separately fails its own case with the swallowed header reappearing as one token.

I checked the fix does not over-correct: spans and strikethroughs that wrap a single line break still lex as before, and I diffed the token output against a binary built from master to confirm those cases are byte-identical.

`go test ./...` passes across all packages.
