### PR TITLE
perf(svg): defer embedded font encoding until output is written

### DIFF
--- a/formatters/api.go
+++ b/formatters/api.go
@@ -23,7 +23,7 @@ var (
 	}))
 	// Default HTML formatter outputs self-contained HTML.
 	htmlFull = Register("html", html.New(html.Standalone(true), html.WithClasses(true))) // nolint
-	SVG      = Register("svg", svg.New(svg.EmbedFont("Liberation Mono", svg.FontLiberationMono(), svg.WOFF)))
+	SVG      = Register("svg", svg.New(svg.EmbedFontProvider("Liberation Mono", svg.FontLiberationMono, svg.WOFF)))
 )
 
 // Fallback formatter.

--- a/formatters/svg/svg.go
+++ b/formatters/svg/svg.go
@@ -44,6 +44,13 @@ func EmbedFontFile(fontFamily string, fileName string) (option Option, err error
 
 // EmbedFont embeds given base64 encoded font
 func EmbedFont(fontFamily string, font string, format FontFormat) Option {
+	return EmbedFontProvider(fontFamily, func() string { return font }, format)
+}
+
+// EmbedFontProvider embeds the base64 encoded font returned by font, which
+// is not called until the formatter actually writes output. Use this instead
+// of EmbedFont when producing the font data is expensive.
+func EmbedFontProvider(fontFamily string, font func() string, format FontFormat) Option {
 	return func(f *Formatter) { f.fontFamily = fontFamily; f.embeddedFont = font; f.fontFormat = format }
 }
 
@@ -59,7 +66,7 @@ func New(options ...Option) *Formatter {
 // Formatter that generates SVG.
 type Formatter struct {
 	fontFamily   string
-	embeddedFont string
+	embeddedFont func() string
 	fontFormat   FontFormat
 }
 
@@ -93,7 +100,7 @@ func (f *Formatter) writeSVG(w io.Writer, style *chroma.Style, tokens []chroma.T
 		return err
 	}
 
-	if f.embeddedFont != "" {
+	if f.embeddedFont != nil {
 		if err := f.writeFontStyle(w); err != nil {
 			return err
 		}
@@ -192,7 +199,7 @@ func (f *Formatter) writeFontStyle(w io.Writer) error {
 	font-weight: normal;
 	font-style: normal;
 }
-</style>`, f.fontFamily, fontFormats[f.fontFormat].mime, f.embeddedFont, fontFormats[f.fontFormat].format)
+</style>`, f.fontFamily, fontFormats[f.fontFormat].mime, f.embeddedFont(), fontFormats[f.fontFormat].format)
 	return err
 }
 


### PR DESCRIPTION
Registering the default SVG formatter base64-encodes the embedded 390 KB Liberation Mono font at init, in every program importing the formatters package. This adds an EmbedFontProvider option that takes the font as a func() string and defers the call until the formatter actually writes output. EmbedFont is unchanged and now wraps it.

| `GODEBUG=inittrace=1` | init clock | init heap |
|---|---|---|
| before | 0.57 ms | 509 KB |
| after | 0.14 ms | 34 KB |

Part of a series reducing the cost of importing chroma (lexers + styles + formatters) from ~15.4 ms to ~1.1 ms.
