### PR TITLE
fix(html): align table line numbers with flex layout

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -515,6 +515,21 @@ func (f *Formatter) WriteCSS(w io.Writer, style *chroma.Style) error {
 			return err
 		}
 	}
+	// Special-case the line number column of the table so its lines use the
+	// same flex layout as the code column. The code column's Line already sets
+	// "display: flex", so without this an inherited line-height greater than one
+	// makes the highlighted line numbers a different height to the highlighted
+	// code they sit beside.
+	if f.lineNumbers && f.lineNumbersInTable {
+		selector := fmt.Sprintf(
+			"%s .%s .%s, %s .%s .%s",
+			chromaSel, f.class(chroma.LineTable), f.class(chroma.LineNumbersTable),
+			chromaSel, f.class(chroma.LineTable), f.class(chroma.LineHighlight),
+		)
+		if err := f.writeCSSRule(w, chroma.LineTable.String(), selector, "display: flex;"); err != nil {
+			return err
+		}
+	}
 	// Special-case line number highlighting when targeted.
 	if f.lineNumbers || f.lineNumbersInTable {
 		targetedLineCSS := StyleEntryToCSS(style.Get(chroma.LineHighlight))

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -314,6 +314,24 @@ func TestTableLinkeableLineNumbers(t *testing.T) {
 	assert.Contains(t, buf.String(), `/* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }`, buf.String())
 }
 
+func TestTableLineNumbersFlex(t *testing.T) {
+	// With LineNumbersInTable the code column's lines are flex containers, so the
+	// line number column must match to keep highlighted numbers the same height
+	// as the highlighted code when line-height > 1. See #722.
+	f := New(WithClasses(true), WithLineNumbers(true), LineNumbersInTable(true))
+
+	var buf bytes.Buffer
+	err := f.WriteCSS(&buf, styles.Fallback)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), `.chroma .lntable .lnt, .chroma .lntable .hl { display: flex; }`, buf.String())
+
+	// Not emitted unless line numbers are rendered in a table.
+	var plain bytes.Buffer
+	err = New(WithClasses(true), WithLineNumbers(true)).WriteCSS(&plain, styles.Fallback)
+	assert.NoError(t, err)
+	assert.NotContains(t, plain.String(), `.lntable .lnt`)
+}
+
 func TestTableLineNumberSpacing(t *testing.T) {
 	testCases := []struct {
 		baseLineNumber int


### PR DESCRIPTION
Fixes the long-standing misalignment where, with `LineNumbersInTable` enabled and an inherited `line-height` greater than one, highlighted line numbers are a different height to the highlighted code beside them (#722).

The code column already lays each line out as a flex container (`.chroma .line { display: flex; }`), but the line number column's spans are left inline. When the line-height is stretched, the two columns compute row heights differently, so a highlighted number no longer matches the height of the code on the same row.

This emits a scoped rule from `WriteCSS`, alongside the existing table special-cases, that gives the line number column the same flex layout:

```css
.chroma .lntable .lnt, .chroma .lntable .hl { display: flex; }
```

This is the fix @willfaught proposed on the issue; the companion "second column takes the remaining width" suggestion is already handled by the existing `.lntd:last-child { width: 100% }` rule. The rule is only written when line numbers are actually rendered in a table (`WithLineNumbers` + `LineNumbersInTable`), so default output and the non-table line number modes are unchanged.

Testing: added `TestTableLineNumbersFlex`, which asserts the rule is present for the table mode and absent for plain line numbers. `go test ./...` passes, and `go vet` / `gofmt` are clean.