### PR TITLE
fix(lexers): let GDScript win the *.gd filename match

### DIFF
--- a/lexers/embedded/gdscript3.xml
+++ b/lexers/embedded/gdscript3.xml
@@ -6,6 +6,7 @@
     <filename>*.gd</filename>
     <mime_type>text/x-gdscript</mime_type>
     <mime_type>application/x-gdscript</mime_type>
+    <priority>0.05</priority>
     <analyse>
       <regex pattern="func (_ready|_init|_input|_process|_unhandled_input)" score="0.8"/>
       <regex pattern="(extends |class_name |onready |preload|load|setget|func [^_])" score="0.4"/>

--- a/lexers/lexers_gen.go
+++ b/lexers/lexers_gen.go
@@ -1283,6 +1283,7 @@ var embeddedLexers = []struct {
 			"text/x-gdscript",
 			"application/x-gdscript",
 		},
+		Priority: 0.05,
 		Analyse: &chroma.AnalyseConfig{
 			Regexes: []chroma.RegexConfig{
 				{

--- a/lexers/lexers_test.go
+++ b/lexers/lexers_test.go
@@ -43,6 +43,14 @@ func TestGet(t *testing.T) {
 			repr.String(expected.Config(), repr.Indent("  ")),
 			repr.String(actual.Config(), repr.Indent("  ")))
 	})
+	// GDScript and GDScript3 both claim *.gd, so the more recent dialect has to win.
+	t.Run("ViaFilenameWithCompetingLexers", func(t *testing.T) {
+		expected := lexers.Get("GDScript")
+		actual := lexers.GlobalLexerRegistry.Get("test.gd")
+		assert.Equal(t,
+			repr.String(expected.Config(), repr.Indent("  ")),
+			repr.String(actual.Config(), repr.Indent("  ")))
+	})
 }
 
 func TestAliases(t *testing.T) {


### PR DESCRIPTION
There is a bug where GDScript v3 is prioritised over GDScript v4:
<img width="2034" height="1953" alt="Screenshot_20260827_214445" src="https://github.com/user-attachments/assets/41006ee2-43c3-4abe-a52f-6b3d946cc40b" />
As a result, things like `class_name` are not properly rendered.

This PR solves this by prioritising GDScript v4 over v3.