### PR TITLE
fix(formatters): emit the token background in mirc16m

### DIFF
--- a/formatters/mirc.go
+++ b/formatters/mirc.go
@@ -208,6 +208,9 @@ func mIRCHexColorFormatter(w io.Writer, style *chroma.Style, it iter.Seq[chroma.
 		}
 		if entry.Colour.IsSet() {
 			formatting += fmt.Sprintf("\x04%02X%02X%02X", entry.Colour.Red(), entry.Colour.Green(), entry.Colour.Blue())
+			if entry.Background.IsSet() {
+				formatting += fmt.Sprintf(",%02X%02X%02X", entry.Background.Red(), entry.Background.Green(), entry.Background.Blue())
+			}
 		}
 
 		if err := mIRCwriteToken(w, formatting, token.Value); err != nil {

--- a/formatters/mirc_test.go
+++ b/formatters/mirc_test.go
@@ -31,3 +31,18 @@ func TestNoneIRCColour(t *testing.T) {
 
 	assert.Equal(t, "\x0342WORD\x0f", stringBuilder.String())
 }
+
+func TestHexIRCBackgroundColour(t *testing.T) {
+	style, err := chroma.NewStyle("test", chroma.StyleEntries{
+		chroma.Error: "#960050 bg:#1e0010",
+	})
+	assert.NoError(t, err)
+
+	stringBuilder := strings.Builder{}
+	err = MIRC16m.Format(&stringBuilder, style, chroma.Literator(chroma.Token{
+		Type:  chroma.Error,
+		Value: "WORD",
+	}))
+	assert.NoError(t, err)
+	assert.Equal(t, "\x04960050,1E0010WORD\x0f", stringBuilder.String())
+}


### PR DESCRIPTION
`mirc16m` is the only colour formatter that drops a token's background.

Four formatters build a formatting prefix from a `chroma.StyleEntry`. Three emit the background;
this one doesn't:

| formatter | file:line | foreground | background |
|---|---|---|---|
| terminal / 8 / 16 / 256 | `formatters/tty_indexed.go:202,205` | `entry.Colour.IsSet()` | `entry.Background.IsSet()` |
| terminal16m | `formatters/tty_truecolour.go:60,63` | `entry.Colour.IsSet()` | `entry.Background.IsSet()` |
| mirc100 | `formatters/mirc.go:172,175` | `entry.Colour.IsSet()` | `entry.Background.IsSet()` |
| **mirc16m** | **`formatters/mirc.go:209`** | `entry.Colour.IsSet()` | **absent** |

`mirc100` is the adjacent function in the same file from the same PR (#1343), so the shape here is
just its twin's.

### Reachable

`clearBackground()` (`formatters/tty_indexed.go:235`) only zeroes the global `chroma.Background`
entry, so per-token backgrounds survive into the formatter. 21 of the 79 bundled styles set one on
`Error` alone — e.g. `styles/monokai.xml:2`, `Error style="#960050 bg:#1e0010"`.

Same token, same style, through each formatter:

```
terminal     "\x1b[35m\x1b[40mbad\x1b[0m"
terminal16m  "\x1b[38;2;150;0;80m\x1b[48;2;30;0;16mbad\x1b[0m"
mirc100      "\x0339,89bad\x0f"
mirc16m      "\x04960050bad\x0f"        <- no background
```

The `,RRGGBB` form is what the hex colour code takes: modern.ircdocs.horse/formatting gives
`0x04RRGGBB,RRGGBB`, matching the `\x03NN,NN` pair `mirc100` already emits.

### Change

Three lines, mirroring `mirc100`. Test added in the file's existing idiom; red before
(`-960050,1E0010WORD` / `+960050WORD`), green after. `go test ./...` passes across all packages,
`gofmt -l` and `go vet` show no change from `master`.

Not included, in case you want it separately: both mIRC formatters nest the background inside
`Colour.IsSet()`, so a background-only entry (`styles/lovelace.xml:2`, `Error style="bg:#a848a8"`)
still drops it in `mirc100` too. That needs the background-only `\x03,NN` / `\x04,RRGGBB` form,
which the spec is less clear about, so I left it alone rather than guess.

---

Disclosure: prepared with AI assistance; I verified the reproduction, the red/green runs and the
test suite myself.
