### PR TITLE
fix(formatters/html): give line-number-table rows their own flex box

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -336,7 +336,10 @@ func (f *Formatter) writeHTML(w io.Writer, style *chroma.Style, tokens []chroma.
 				if f.classes {
 					fmt.Fprintf(w, ` class="%s %s"`, html.EscapeString(f.class(chroma.Line)), html.EscapeString(f.class(chroma.LineHighlight)))
 				} else {
-					fmt.Fprintf(w, ` style="%s %s"`, css[chroma.Line], css[chroma.LineHighlight])
+					// LineHighlight's own display:flex (needed when it wraps a
+					// line-number-table row on its own, #722) is redundant
+					// here since Line already sets it.
+					fmt.Fprintf(w, ` style="%s %s"`, css[chroma.Line], strings.TrimPrefix(css[chroma.LineHighlight], "display:flex;"))
 				}
 				fmt.Fprint(w, `>`)
 			} else {
@@ -599,10 +602,16 @@ func (f *Formatter) styleToCSS(style *chroma.Style) map[chroma.TokenType]string 
 	// All rules begin with default rules followed by user provided rules
 	classes[chroma.Line] = `display: flex;` + classes[chroma.Line]
 	classes[chroma.LineNumbers] = lineNumbersStyle + classes[chroma.LineNumbers]
-	classes[chroma.LineNumbersTable] = lineNumbersStyle + classes[chroma.LineNumbersTable]
+	// Each line-number-table row has no .line wrapper of its own, so it needs
+	// its own flex box to match the height of its .line counterpart (#722).
+	classes[chroma.LineNumbersTable] = `display: flex; ` + lineNumbersStyle + classes[chroma.LineNumbersTable]
 	if len(f.linePromptRanges) > 0 {
 		classes[chroma.GenericPrompt] = linePromptStyle + classes[chroma.GenericPrompt]
 	}
+	// In the line-number table, a highlighted row's .hl span (not .line) is
+	// the row being flexed; harmless when .hl is instead combined with an
+	// already-flex .line elsewhere (#722).
+	classes[chroma.LineHighlight] = `display: flex; ` + classes[chroma.LineHighlight]
 	classes[chroma.LineTable] = "border-spacing: 0; padding: 0; margin: 0; border: 0;" + classes[chroma.LineTable]
 	classes[chroma.LineTableTD] = "vertical-align: top; padding: 0; margin: 0; border: 0;" + classes[chroma.LineTableTD]
 	classes[chroma.LineLink] = "outline: none; text-decoration: none; color: inherit" + classes[chroma.LineLink]

--- a/formatters/html/html_test.go
+++ b/formatters/html/html_test.go
@@ -359,6 +359,33 @@ func TestTableLineNumberSpacing(t *testing.T) {
 	}
 }
 
+// https://github.com/alecthomas/chroma/issues/722
+func TestTableLineNumberRowHeight(t *testing.T) {
+	t.Run("Classes", func(t *testing.T) {
+		f := New(WithClasses(true), WithLineNumbers(true), LineNumbersInTable(true), HighlightLines([][2]int{{2, 2}}))
+		var buf bytes.Buffer
+		err := f.WriteCSS(&buf, styles.Fallback)
+		assert.NoError(t, err)
+		// Unhighlighted row: .lnt is the row and needs its own flex box.
+		assert.Contains(t, buf.String(), ".chroma .lnt { display: flex;")
+		// Highlighted row: .hl (not .lnt) is the row.
+		assert.Contains(t, buf.String(), ".chroma .hl { display: flex;")
+	})
+
+	t.Run("InlineStyles", func(t *testing.T) {
+		f := New(WithLineNumbers(true), LineNumbersInTable(true), HighlightLines([][2]int{{2, 2}}))
+		it, err := lexers.Get("go").Tokenise(nil, "package main\nfunc main()\n{\nprintln(`hello world`)\n}\n")
+		assert.NoError(t, err)
+		var buf bytes.Buffer
+		err = f.Format(&buf, styles.Fallback, it)
+		assert.NoError(t, err)
+		// Unhighlighted row.
+		assert.Contains(t, buf.String(), `<span style="display:flex;white-space:pre;`)
+		// Highlighted row: the .hl-equivalent wrapping span gets the flex box.
+		assert.Contains(t, buf.String(), `<span style="display:flex;background-color:`)
+	})
+}
+
 func TestWithPreWrapper(t *testing.T) {
 	wrapper := preWrapper{
 		start: func(code bool, styleAttr string) string {

--- a/quick/example_test.go
+++ b/quick/example_test.go
@@ -25,8 +25,8 @@ func main() { }
 	// /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 	// /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 	// /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-	// /* LineHighlight */ .chroma .hl { background-color: #3c3d38 }
-	// /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+	// /* LineHighlight */ .chroma .hl { display: flex; background-color: #3c3d38 }
+	// /* LineNumbersTable */ .chroma .lnt { display: flex; white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 	// /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 	// /* Line */ .chroma .line { display: flex; }
 	// /* Keyword */ .chroma .k { color: #66d9ef }


### PR DESCRIPTION
Each row in the line-number-table (.lnt) has no .line wrapper of its own, so it never stretched to match the height of a highlighted line. Give .lnt display:flex directly, and give .hl the same since it becomes the row wrapper instead of .lnt when a row is highlighted.

When a line is both .line and .hl, the inline-style path already combines their two style strings; strip the now-duplicate display:flex from .hl's side before joining so the merged style stays correct.

Fixes #722